### PR TITLE
[refactor] ProjectConfig 설정 경로 상수화 및 부모 프로세스 선로딩

### DIFF
--- a/src/common/process/step_process.py
+++ b/src/common/process/step_process.py
@@ -16,8 +16,8 @@ class StepProcess(QueueProcess):
         self._state_machine: StateMachine | None = None
 
     def _set_config(self) -> None:
-        AppLogger.set_config("./conf/application.conf", self.name)
-        ProjectConfig.set_config("./conf/application.conf")
+        AppLogger.set_config(ProjectConfig.DEFAULT_CONFIG_PATH, self.name)
+        ProjectConfig.set_config(ProjectConfig.DEFAULT_CONFIG_PATH)
 
     def get_app_name(self) -> str:
         return self._app_name

--- a/src/config/project_config.py
+++ b/src/config/project_config.py
@@ -3,6 +3,8 @@ from python_library.define.enum import IENUM
 
 
 class ProjectConfig(AppConfig):
+    DEFAULT_CONFIG_PATH = "./conf/application.conf"
+
     class E_CATE_TYPE(IENUM):
         COMMON = "COOMON"
         IMDG = "IMDG"

--- a/src/downloader_app.py
+++ b/src/downloader_app.py
@@ -3,6 +3,7 @@ import time
 from app.app_object import MultiProcessManagerAppFromCate
 from process_category.enum_category import E_CATE
 from process_category.process_category import ProcessCategory
+from config.project_config import ProjectConfig
 
 
 class Downloader(MultiProcessManagerAppFromCate):
@@ -19,6 +20,8 @@ class Downloader(MultiProcessManagerAppFromCate):
 
 
 def main():
+    ProjectConfig.set_config(ProjectConfig.DEFAULT_CONFIG_PATH)
+
     ProcessCategory.instance().register_downloader()
 
     app = Downloader(E_CATE.DOWNLOADER)

--- a/src/message_bridge_app.py
+++ b/src/message_bridge_app.py
@@ -3,6 +3,7 @@ import time
 from app.app_object import MultiProcessManagerAppFromCate
 from process_category.enum_category import E_CATE
 from process_category.process_category import ProcessCategory
+from config.project_config import ProjectConfig
 
 
 class MessageBridge(MultiProcessManagerAppFromCate):
@@ -19,6 +20,8 @@ class MessageBridge(MultiProcessManagerAppFromCate):
 
 
 def main():
+    ProjectConfig.set_config(ProjectConfig.DEFAULT_CONFIG_PATH)
+
     ProcessCategory.instance().register_message_bridge()
 
     app = MessageBridge(E_CATE.MESSAGE_BRIDGE)

--- a/src/rest_server_app.py
+++ b/src/rest_server_app.py
@@ -3,6 +3,7 @@ import time
 from app.app_object import MultiProcessManagerAppFromCate
 from process_category.enum_category import E_CATE
 from process_category.process_category import ProcessCategory
+from config.project_config import ProjectConfig
 
 
 class RestServer(MultiProcessManagerAppFromCate):
@@ -18,6 +19,8 @@ class RestServer(MultiProcessManagerAppFromCate):
 
 
 def main():
+    ProjectConfig.set_config(ProjectConfig.DEFAULT_CONFIG_PATH)
+
     ProcessCategory.instance().register_rest_server()
 
     app = RestServer(E_CATE.REST_SERVER)


### PR DESCRIPTION
## Summary
- ProjectConfig.DEFAULT_CONFIG_PATH 상수 도입으로 "./conf/application.conf" 하드코딩 제거
- downloader/message_bridge/rest_server 의 main() 에서 ProjectConfig.set_config 를 선호출하여 Process __init__ 단계의 ProjectConfig.instance() 참조를 안전하게 지원
- step_process.py 및 각 app 파일에서 상수 참조로 일원화

## Related Issue
close #22