### PR TITLE
[refactor] Packet을 IPacket 인터페이스와 abPacket 추상 클래스로 분리

### DIFF
--- a/src/app/downloader/process/downloader_manager.py
+++ b/src/app/downloader/process/downloader_manager.py
@@ -2,7 +2,7 @@ from python_library.process.process import abProcess
 
 from common.event_bus.listener.stream_listener import StreamListener
 from common.process.imdg_bus_process import ImdgBusProcess
-from protocol.message.packet import Packet
+from protocol.message.packet import IPacket
 
 
 class DownloaderManager(ImdgBusProcess):
@@ -16,7 +16,7 @@ class DownloaderManager(ImdgBusProcess):
         self._stream_listener.start()
 
     @staticmethod
-    def playable_list_request(process: abProcess, packet: Packet):
+    def playable_list_request(process: abProcess, packet: IPacket):
         pass
 
     def action(self) -> None:

--- a/src/app/downloader/process/downloader_module.py
+++ b/src/app/downloader/process/downloader_module.py
@@ -1,7 +1,7 @@
 from python_library.process.process import abProcess
 
 from common.process.queue_control_process import QueueControlProcess
-from protocol.message.packet import Packet
+from protocol.message.packet import IPacket
 
 
 class DownloaderModule(QueueControlProcess):
@@ -10,7 +10,7 @@ class DownloaderModule(QueueControlProcess):
         pass
 
     @staticmethod
-    def playable_list_request(process: abProcess, packet: Packet):
+    def playable_list_request(process: abProcess, packet: IPacket):
         pass
 
     def action(self) -> None:

--- a/src/app/message_bridge/process/message_bridge_process.py
+++ b/src/app/message_bridge/process/message_bridge_process.py
@@ -1,7 +1,7 @@
 from common.event_bus.stream_bus import StreamBus
 from common.process.imdg_bus_process import ImdgBusProcess
 from common.process.interfaces import IBusProcess
-from protocol.message.packet import E_PROTOCOL_MESSAGE_DIRECTION, Packet
+from protocol.message.packet import E_PROTOCOL_MESSAGE_DIRECTION, IPacket
 from protocol.protocol_meta import E_PROTOCOL_ID, ProtocolMeta
 
 
@@ -18,7 +18,7 @@ class MessageBridgeProcess(ImdgBusProcess):
         self._stream_bus.publish(message)
 
     @staticmethod
-    def playable_list_request(process: IBusProcess, packet: Packet):
+    def playable_list_request(process: IBusProcess, packet: IPacket):
         from process_category.enum_category import E_CATE
         from protocol.protocol_owner import ProtocolOwner
         sender = ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE)

--- a/src/protocol/message/external/external.py
+++ b/src/protocol/message/external/external.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
 from typing import Type
 
-from protocol.message.packet import Packet, T
+from protocol.message.packet import abPacket, T
 
 
 @dataclass
-class ExternalPacket(Packet):
+class ExternalPacket(abPacket):
 
     def to_json(self) -> str:
         # 내부 저장/디버깅/로그 목적

--- a/src/protocol/message/ipc/ipc.py
+++ b/src/protocol/message/ipc/ipc.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Type
 
-from protocol.message.packet import Packet, T
+from protocol.message.packet import abPacket, T
 
 
 @dataclass(frozen=True)
@@ -12,7 +12,7 @@ class Response:
 
 
 @dataclass
-class IpcPacket(Packet):
+class IpcPacket(abPacket):
 
     def to_json(self) -> str:
         return self._encode_internal(self)

--- a/src/protocol/message/packet.py
+++ b/src/protocol/message/packet.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import json
+from abc import ABC, abstractmethod
 from dataclasses import asdict, is_dataclass, dataclass
 from enum import Enum, IntEnum
 from typing import Any, Mapping, Type, TypeVar
 
 from define.define import E_COMMUNICATION_TYPE
 
-T = TypeVar("T", bound="Packet")
+T = TypeVar("T", bound="abPacket")
 
 
 class PacketCodecError(ValueError):
@@ -41,22 +42,23 @@ class Header:
     receiver: str
 
 
-@dataclass
-class Packet:
+class IPacket(ABC):
     header: Header
 
-    # ---- interface ----
-    def to_json(self) -> str:
-        """Internal serialization (typically used within your system)."""
-        raise NotImplementedError
+    @abstractmethod
+    def to_json(self) -> str: ...
 
-    def to_json_public(self) -> str:
-        """External/wire serialization (typically used for integration)."""
-        raise NotImplementedError
+    @abstractmethod
+    def to_json_public(self) -> str: ...
 
     @classmethod
-    def from_json(cls: Type[T], json_data: str) -> T:
-        raise NotImplementedError
+    @abstractmethod
+    def from_json(cls: Type[T], json_data: str) -> T: ...
+
+
+@dataclass
+class abPacket(IPacket):
+    header: Header
 
     # ---- shared helpers ----
     @staticmethod

--- a/src/protocol/protocol_meta.py
+++ b/src/protocol/protocol_meta.py
@@ -6,12 +6,12 @@ from typing import Any, Callable, Dict, Mapping, ClassVar
 
 from python_library.process.process import abProcess
 
-from protocol.message.packet import E_PROTOCOL_MESSAGE_DIRECTION, Packet
+from protocol.message.packet import E_PROTOCOL_MESSAGE_DIRECTION, IPacket
 
 ReceiverKey = Any
-FactoryFn = Callable[..., Packet]
-DecoderFn = Callable[[Any], Packet]
-HandlerFn = Callable[[abProcess, Packet], Any]
+FactoryFn = Callable[..., IPacket]
+DecoderFn = Callable[[Any], IPacket]
+HandlerFn = Callable[[abProcess, IPacket], Any]
 
 
 class E_PROTOCOL_ID(Enum):

--- a/src/protocol/protocol_wrapper.py
+++ b/src/protocol/protocol_wrapper.py
@@ -1,7 +1,7 @@
 from enum import IntEnum
 
 from define.define import E_COMMUNICATION_TYPE
-from protocol.message.packet import Packet
+from protocol.message.packet import IPacket
 from utils.jsonpickle_util import JsonpickleUtil
 from utils.string_builder import StringBuilder
 from utils.time_string_fit import TimeStringFit, E_TIMEFORMAT
@@ -21,7 +21,7 @@ class ProtocolWrapper:
 
     sequence_id = dict()
 
-    def __init__(self, message_id, protocol_message: Packet):
+    def __init__(self, message_id, protocol_message: IPacket):
         try:
             self.communication_type = protocol_message.header.communication_type
         except Exception as e:


### PR DESCRIPTION
## Summary
- IPacket(ABC) 신설: 순수 계약(to_json, to_json_public, from_json, header) 선언
- Packet → abPacket(IPacket) 리네임: 공유 상태(header dataclass) 및 정적 헬퍼(_encode_*/_decode_*) 담당
- raise NotImplementedError → @abstractmethod 로 전환해 계약 의도 선언적 표현
- IpcPacket/ExternalPacket 의 부모를 abPacket 으로 교체
- 핸들러·레지스트리(FactoryFn/DecoderFn/HandlerFn)·ProtocolWrapper 의 타입 힌트를 Packet → IPacket 으로 narrow
- I*/ab* 네이밍 컨벤션과 일관성 확보

## Related Issue
close #24