### PR TITLE
[refactor] #28 통신 채널 enum 명명 정리 + Imdg/Inner Packet 중간 계층 추가

### DIFF
--- a/src/app/message_bridge/process/message_bridge_process.py
+++ b/src/app/message_bridge/process/message_bridge_process.py
@@ -1,5 +1,5 @@
 from common.process.imdg_bus_process import IImdgBusProcess, ImdgBusProcess
-from protocol.message.packet import E_PROTOCOL_MESSAGE_DIRECTION, IPacket
+from protocol.message.packet import IPacket
 from protocol.protocol_meta import E_PROTOCOL_ID, ProtocolMeta
 
 
@@ -15,7 +15,6 @@ class MessageBridgeProcess(ImdgBusProcess):
         receiver = ProtocolOwner.build(E_CATE.DOWNLOADER, E_CATE.E_DOWNLOADER.E_COMMON.DOWNLOAD_MANAGER)
         factory = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PLAYABLE_LIST_REQ)
         fwd_packet = factory(
-            E_PROTOCOL_MESSAGE_DIRECTION.REQUEST.value,
             sender,
             receiver,
             packet.vehicle_id,

--- a/src/app/rest/websocket_server.py
+++ b/src/app/rest/websocket_server.py
@@ -8,7 +8,6 @@ import uvicorn
 from common.process.imdg_bus_process import IImdgBusProcess
 from common.process.queue_control_process import QueueControlProcess
 from protocol.message.external.ui.playable_list import PDPlayableListReq
-from protocol.message.packet import E_PROTOCOL_MESSAGE_DIRECTION
 from protocol.protocol_meta import ProtocolMeta, E_PROTOCOL_ID
 from protocol.protocol_owner import ProtocolOwner
 
@@ -72,7 +71,6 @@ class SocketIOServer(abWebSocketServer):
         receiver = ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE)
 
         message = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PLAYABLE_LIST_REQ)(
-            E_PROTOCOL_MESSAGE_DIRECTION.REQUEST,
             sender,
             receiver,
             protocol_message.vehicle_id,

--- a/src/define/define.py
+++ b/src/define/define.py
@@ -9,14 +9,14 @@ class E_META_COLUMN(IntEnum):
 
 class E_COMMUNICATION_TYPE(IntEnum):
     IMDG = 0
-    PROCESS = 1
-    NORMAL = 2
+    INNER = 1
+    EXTERNAL = 2
 
     # Enum 멤버로 안 들어가게만 nonmember 유지 (타입 문자열 힌트 없음)
     META = nonmember({
-        IMDG: {E_META_COLUMN.NAME: "IMDG", E_META_COLUMN.SYMBOL: "DG"},
-        PROCESS: {E_META_COLUMN.NAME: "PROCESS", E_META_COLUMN.SYMBOL: "IN"},
-        NORMAL: {E_META_COLUMN.NAME: "NORMAL", E_META_COLUMN.SYMBOL: "NO"},
+        IMDG: {E_META_COLUMN.NAME: "IMDG", E_META_COLUMN.SYMBOL: "IMDG"},
+        INNER: {E_META_COLUMN.NAME: "INNER", E_META_COLUMN.SYMBOL: "INNER"},
+        EXTERNAL: {E_META_COLUMN.NAME: "EXTERNAL", E_META_COLUMN.SYMBOL: "EXTERNAL"},
     })
 
     _SYMBOL_TO_TYPE = nonmember(None)  # dict[str, E_COMMUNICATION_TYPE] | None

--- a/src/protocol/message/external/ui/playable_list.py
+++ b/src/protocol/message/external/ui/playable_list.py
@@ -21,7 +21,7 @@ class PDPlayableListRep(ExternalPacket):
     ) -> None:
         super().__init__(
             header=Header(
-                communication_type=E_COMMUNICATION_TYPE.NORMAL,
+                communication_type=E_COMMUNICATION_TYPE.EXTERNAL,
                 protocol_id=protocol_id,
                 sender=sender,
                 receiver=receiver,
@@ -51,7 +51,7 @@ class PDPlayableListReq(ExternalPacket):
     ) -> None:
         super().__init__(
             header=Header(
-                communication_type=E_COMMUNICATION_TYPE.NORMAL,
+                communication_type=E_COMMUNICATION_TYPE.EXTERNAL,
                 message_direction=E_PROTOCOL_MESSAGE_DIRECTION(message_direction),
                 protocol_id=protocol_id,
                 sender=sender,

--- a/src/protocol/message/ipc/imdg/playable_list.py
+++ b/src/protocol/message/ipc/imdg/playable_list.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from define.define import E_COMMUNICATION_TYPE
-from protocol.message.ipc.ipc import IpcRequestPacket
-from protocol.message.packet import Header, E_PROTOCOL_MESSAGE_DIRECTION
+from protocol.message.ipc.ipc import ImdgRequestPacket
 
 
 @dataclass
-class PlayableListReq(IpcRequestPacket):
+class PlayableListReq(ImdgRequestPacket):
 
     vehicle_id: str = ""
     sensor_id_list: list = None
@@ -18,7 +16,6 @@ class PlayableListReq(IpcRequestPacket):
     def __init__(
         self,
         protocol_id: str,
-        message_direction: int,
         sender: str,
         receiver: str,
         vehicle_id: str,
@@ -26,15 +23,7 @@ class PlayableListReq(IpcRequestPacket):
         start_time: str,
         end_time: str,
     ) -> None:
-        super().__init__(
-            header=Header(
-                communication_type=E_COMMUNICATION_TYPE.IMDG,
-                message_direction=E_PROTOCOL_MESSAGE_DIRECTION(message_direction),
-                protocol_id=protocol_id,
-                sender=sender,
-                receiver=receiver,
-            )
-        )
+        super().__init__(protocol_id=protocol_id, sender=sender, receiver=receiver)
         self.vehicle_id = vehicle_id
         self.sensor_id_list = sensor_id_list
         self.start_time = start_time

--- a/src/protocol/message/ipc/inner/playable_list.py
+++ b/src/protocol/message/ipc/inner/playable_list.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 
-from define.define import E_COMMUNICATION_TYPE
-from protocol.message.ipc.ipc import IpcRequestPacket, IpcResponsePacket
-from protocol.message.packet import Header
+from protocol.message.ipc.ipc import (
+    InnerRequestPacket,
+    InnerResponsePacket,
+    Response,
+)
 
 
 # -----------------------------
@@ -10,7 +12,7 @@ from protocol.message.packet import Header
 # -----------------------------
 
 @dataclass
-class InrPlayableListReq(IpcRequestPacket):
+class InrPlayableListReq(InnerRequestPacket):
     vehicle_id: str = ""
     start_time: str = ""
     end_time: str = ""
@@ -24,14 +26,7 @@ class InrPlayableListReq(IpcRequestPacket):
         start_time: str,
         end_time: str,
     ) -> None:
-        super().__init__(
-            header=Header(
-                communication_type=E_COMMUNICATION_TYPE.PROCESS,
-                protocol_id=protocol_id,
-                sender=sender,
-                receiver=receiver,
-            )
-        )
+        super().__init__(protocol_id=protocol_id, sender=sender, receiver=receiver)
         self.vehicle_id = vehicle_id
         self.start_time = start_time
         self.end_time = end_time
@@ -42,7 +37,7 @@ class InrPlayableListReq(IpcRequestPacket):
 # -----------------------------
 
 @dataclass
-class InrPlayableListRep(IpcResponsePacket):
+class InrPlayableListRep(InnerResponsePacket):
     sensor_id: str = ""
     section_list: list = None
     return_message: str = ""
@@ -55,17 +50,14 @@ class InrPlayableListRep(IpcResponsePacket):
         sensor_id: str,
         section_list: list,
         return_message: str,
+        response: Response,
     ) -> None:
         super().__init__(
-            header=Header(
-                communication_type=E_COMMUNICATION_TYPE.PROCESS,
-                protocol_id=protocol_id,
-                sender=sender,
-                receiver=receiver,
-            ),
-            return_code=None
+            protocol_id=protocol_id,
+            sender=sender,
+            receiver=receiver,
+            response=response,
         )
-
         self.sensor_id = sensor_id
         self.section_list = section_list
         self.return_message = return_message

--- a/src/protocol/message/ipc/ipc.py
+++ b/src/protocol/message/ipc/ipc.py
@@ -1,7 +1,13 @@
 from dataclasses import dataclass
 from typing import Type
 
-from protocol.message.packet import abPacket, T
+from define.define import E_COMMUNICATION_TYPE
+from protocol.message.packet import (
+    Header,
+    E_PROTOCOL_MESSAGE_DIRECTION,
+    abPacket,
+    T,
+)
 
 
 @dataclass(frozen=True)
@@ -24,15 +30,117 @@ class IpcPacket(abPacket):
     @classmethod
     def from_json(cls: Type[T], json_data: str) -> T:
         return cls._decode_internal(expected_type=cls, json_data=json_data)
-    pass
 
 
 @dataclass
-class IpcRequestPacket(IpcPacket):
-    pass
+class ImdgPacket(IpcPacket):
+    """앱 간 통신 packet. communication_type=IMDG 자동 부여."""
+
+    def __init__(
+        self,
+        protocol_id: str,
+        message_direction: E_PROTOCOL_MESSAGE_DIRECTION,
+        sender: str,
+        receiver: str,
+    ) -> None:
+        super().__init__(
+            header=Header(
+                communication_type=E_COMMUNICATION_TYPE.IMDG,
+                message_direction=message_direction,
+                protocol_id=protocol_id,
+                sender=sender,
+                receiver=receiver,
+            )
+        )
 
 
 @dataclass
-class IpcResponsePacket(IpcPacket):
+class ImdgRequestPacket(ImdgPacket):
+    """IMDG REQUEST packet. message_direction=REQUEST 자동 부여."""
+
+    def __init__(self, protocol_id: str, sender: str, receiver: str) -> None:
+        super().__init__(
+            protocol_id=protocol_id,
+            message_direction=E_PROTOCOL_MESSAGE_DIRECTION.REQUEST,
+            sender=sender,
+            receiver=receiver,
+        )
+
+
+@dataclass
+class ImdgResponsePacket(ImdgPacket):
+    """IMDG RESPONSE packet. message_direction=RESPONSE 자동 부여."""
+
     response: Response
-    pass
+
+    def __init__(
+        self,
+        protocol_id: str,
+        sender: str,
+        receiver: str,
+        response: Response,
+    ) -> None:
+        super().__init__(
+            protocol_id=protocol_id,
+            message_direction=E_PROTOCOL_MESSAGE_DIRECTION.RESPONSE,
+            sender=sender,
+            receiver=receiver,
+        )
+        self.response = response
+
+
+@dataclass
+class InnerPacket(IpcPacket):
+    """앱 내 자식 프로세스 간 통신 packet. communication_type=INNER 자동 부여."""
+
+    def __init__(
+        self,
+        protocol_id: str,
+        message_direction: E_PROTOCOL_MESSAGE_DIRECTION,
+        sender: str,
+        receiver: str,
+    ) -> None:
+        super().__init__(
+            header=Header(
+                communication_type=E_COMMUNICATION_TYPE.INNER,
+                message_direction=message_direction,
+                protocol_id=protocol_id,
+                sender=sender,
+                receiver=receiver,
+            )
+        )
+
+
+@dataclass
+class InnerRequestPacket(InnerPacket):
+    """INNER REQUEST packet. message_direction=REQUEST 자동 부여."""
+
+    def __init__(self, protocol_id: str, sender: str, receiver: str) -> None:
+        super().__init__(
+            protocol_id=protocol_id,
+            message_direction=E_PROTOCOL_MESSAGE_DIRECTION.REQUEST,
+            sender=sender,
+            receiver=receiver,
+        )
+
+
+@dataclass
+class InnerResponsePacket(InnerPacket):
+    """INNER RESPONSE packet. message_direction=RESPONSE 자동 부여."""
+
+    response: Response
+
+    def __init__(
+        self,
+        protocol_id: str,
+        sender: str,
+        receiver: str,
+        response: Response,
+    ) -> None:
+        super().__init__(
+            protocol_id=protocol_id,
+            message_direction=E_PROTOCOL_MESSAGE_DIRECTION.RESPONSE,
+            sender=sender,
+            receiver=receiver,
+        )
+        self.response = response

--- a/src/protocol/protocol_meta.py
+++ b/src/protocol/protocol_meta.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, Mapping, ClassVar
 
 from python_library.process.process import abProcess
 
-from protocol.message.packet import E_PROTOCOL_MESSAGE_DIRECTION, IPacket
+from protocol.message.packet import IPacket
 
 ReceiverKey = Any
 FactoryFn = Callable[..., IPacket]
@@ -93,13 +93,12 @@ class ProtocolMeta:
             ),
         )
 
-        # Normal
+        # IMDG
         cls._register(
             E_PROTOCOL_ID.PLAYABLE_LIST_REQ,
             ProtocolEntry(
-                factory=lambda message_direction, sender, receiver, vehicle_id, sensor_id_list, start_time, end_time: PlayableListReq(
+                factory=lambda sender, receiver, vehicle_id, sensor_id_list, start_time, end_time: PlayableListReq(
                     E_PROTOCOL_ID.PLAYABLE_LIST_REQ.value,
-                    E_PROTOCOL_MESSAGE_DIRECTION(message_direction),
                     sender,
                     receiver,
                     vehicle_id,

--- a/src/protocol/protocol_wrapper.py
+++ b/src/protocol/protocol_wrapper.py
@@ -13,8 +13,8 @@ class ProtocolWrapper:
     class E_PROTOCOL_MESSAGE_ELE(IntEnum):
         COMMUNICATION_TYPE = 0
         MESSAGE_ID = 1
-        PROTOCOL_ID = 2
-        MESSAGE_DIRECTION = 3
+        MESSAGE_DIRECTION = 2
+        PROTOCOL_ID = 3
         SENDER = 4
         RECEIVER = 5
         PROTOCOL_MESSAGE = 6
@@ -22,11 +22,7 @@ class ProtocolWrapper:
     sequence_id = dict()
 
     def __init__(self, message_id, protocol_message: IPacket):
-        try:
-            self.communication_type = protocol_message.header.communication_type
-        except Exception as e:
-            self.communication_type = E_COMMUNICATION_TYPE.NORMAL
-
+        self.communication_type = protocol_message.header.communication_type
         self.protocol_id = protocol_message.header.protocol_id
         self.message_direction = protocol_message.header.message_direction
         self.sender = protocol_message.header.sender
@@ -38,8 +34,8 @@ class ProtocolWrapper:
         sb = StringBuilder()
         sb.append(E_COMMUNICATION_TYPE.get_symbol(self.communication_type)).append(self.DELIM_CHAR) \
             .append(self.message_id).append(self.DELIM_CHAR) \
-            .append(self.protocol_id).append(self.DELIM_CHAR) \
             .append(self.message_direction).append(self.DELIM_CHAR) \
+            .append(self.protocol_id).append(self.DELIM_CHAR) \
             .append(self.sender).append(self.DELIM_CHAR) \
             .append(self.receiver).append(self.DELIM_CHAR) \
             .append(JsonpickleUtil.encode_internal(self.protocol_message))


### PR DESCRIPTION
## Summary
- `E_COMMUNICATION_TYPE` 명명 정리: `PROCESS` → `INNER`, `NORMAL` → `EXTERNAL`. symbol도 약자에서 enum 이름 그대로 통일 (`"DG"`→`"IMDG"`, `"IN"`→`"INNER"`, `"NO"`→`"EXTERNAL"`)
- `ipc.py`에 채널별 중간 계층 추가 (`ImdgPacket`/`InnerPacket` + Request/Response 변형). concrete packet은 `communication_type` / `message_direction` 인자를 더 이상 hardcode하지 않고 부모가 자동 부여
- `PlayableListReq` → `ImdgRequestPacket`, `InrPlayableListReq` → `InnerRequestPacket`, `InrPlayableListRep` → `InnerResponsePacket` 상속
- `ProtocolWrapper` 정리: `E_PROTOCOL_MESSAGE_ELE` 순서 swap (`PROTOCOL_ID` ↔ `MESSAGE_DIRECTION`), 인코딩 순서도 동일하게 반영, `communication_type` fallback try/except 제거
- factory 시그니처 및 호출부에서 redundant `message_direction` 인자 제거

## Related Issue
close #28