### PR TITLE
[refactor] #30 ProtocolWrapper envelope wire format 도입

### DIFF
--- a/src/app/downloader/process/downloader_manager.py
+++ b/src/app/downloader/process/downloader_manager.py
@@ -1,6 +1,7 @@
 from common.event_bus.listener.stream_listener import StreamListener
 from common.process.imdg_bus_process import IImdgBusProcess, ImdgBusProcess
 from protocol.message.packet import IPacket
+from protocol.protocol_wrapper import ProtocolWrapper
 
 
 class DownloaderManager(ImdgBusProcess):
@@ -14,7 +15,7 @@ class DownloaderManager(ImdgBusProcess):
         self._stream_listener.start()
 
     @staticmethod
-    def playable_list_request(process: IImdgBusProcess, packet: IPacket):
+    def playable_list_request(process: IImdgBusProcess, wrapper: ProtocolWrapper, packet: IPacket):
         pass
 
     def action(self) -> None:

--- a/src/app/downloader/process/downloader_module.py
+++ b/src/app/downloader/process/downloader_module.py
@@ -2,6 +2,7 @@ from python_library.process.process import abProcess
 
 from common.process.queue_control_process import QueueControlProcess
 from protocol.message.packet import IPacket
+from protocol.protocol_wrapper import ProtocolWrapper
 
 
 class DownloaderModule(QueueControlProcess):
@@ -10,7 +11,7 @@ class DownloaderModule(QueueControlProcess):
         pass
 
     @staticmethod
-    def playable_list_request(process: abProcess, packet: IPacket):
+    def playable_list_request(process: abProcess, wrapper: ProtocolWrapper, packet: IPacket):
         pass
 
     def action(self) -> None:

--- a/src/app/message_bridge/process/message_bridge_process.py
+++ b/src/app/message_bridge/process/message_bridge_process.py
@@ -1,6 +1,7 @@
 from common.process.imdg_bus_process import IImdgBusProcess, ImdgBusProcess
 from protocol.message.packet import IPacket
 from protocol.protocol_meta import E_PROTOCOL_ID, ProtocolMeta
+from protocol.protocol_wrapper import ProtocolWrapper
 
 
 class MessageBridgeProcess(ImdgBusProcess):
@@ -8,7 +9,7 @@ class MessageBridgeProcess(ImdgBusProcess):
         super().__init__(app_name, process_name)
 
     @staticmethod
-    def playable_list_request(process: IImdgBusProcess, packet: IPacket):
+    def playable_list_request(process: IImdgBusProcess, wrapper: ProtocolWrapper, packet: IPacket):
         from process_category.enum_category import E_CATE
         from protocol.protocol_owner import ProtocolOwner
         sender = ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE)
@@ -22,4 +23,5 @@ class MessageBridgeProcess(ImdgBusProcess):
             packet.start_time,
             packet.end_time,
         )
-        process.send_message_imdg(fwd_packet.to_json())
+        envelope = ProtocolWrapper.get_protocol_wrapper(fwd_packet).get_protocol_packet_message()
+        process.send_message_imdg(envelope)

--- a/src/app/rest/websocket_server.py
+++ b/src/app/rest/websocket_server.py
@@ -10,6 +10,7 @@ from common.process.queue_control_process import QueueControlProcess
 from protocol.message.external.ui.playable_list import PDPlayableListReq
 from protocol.protocol_meta import ProtocolMeta, E_PROTOCOL_ID
 from protocol.protocol_owner import ProtocolOwner
+from protocol.protocol_wrapper import ProtocolWrapper
 
 
 class abWebSocketServer(ABC):
@@ -63,7 +64,11 @@ class SocketIOServer(abWebSocketServer):
         super().__init__(_parents_process, _bind_ip, _bind_port)
 
     @staticmethod
-    def playable_list_request(process: IImdgBusProcess, protocol_message: PDPlayableListReq):
+    def playable_list_request(
+        process: IImdgBusProcess,
+        wrapper: ProtocolWrapper,
+        packet: PDPlayableListReq,
+    ):
         from process_category.enum_category import E_CATE
 
 
@@ -73,13 +78,14 @@ class SocketIOServer(abWebSocketServer):
         message = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PLAYABLE_LIST_REQ)(
             sender,
             receiver,
-            protocol_message.vehicle_id,
-            protocol_message.sensor_id_list,
-            protocol_message.start_time,
-            protocol_message.end_time,
+            packet.vehicle_id,
+            packet.sensor_id_list,
+            packet.start_time,
+            packet.end_time,
         )
 
-        process.send_message_imdg(message.to_json())
+        envelope = ProtocolWrapper.get_protocol_wrapper(message).get_protocol_packet_message()
+        process.send_message_imdg(envelope)
 
     def on_init(self) -> None:
         self.get_parent_process().on_register_handler(ProtocolMeta.get_receive_handler_container())
@@ -100,7 +106,7 @@ class SocketIOServer(abWebSocketServer):
                 return
 
             packet = ProtocolMeta.get_json_decoder(protocol_id)(message)
+            wrapper = ProtocolWrapper.get_protocol_wrapper(packet)
 
             recv_handler = ProtocolMeta.get_receive_handler(protocol_id, receiver_name)
-
-            result = recv_handler(self.get_parent_process(), packet)
+            recv_handler(self.get_parent_process(), wrapper, packet)

--- a/src/common/event_bus/listener/imdg_listener.py
+++ b/src/common/event_bus/listener/imdg_listener.py
@@ -1,5 +1,4 @@
 import time
-import json
 
 from python_library.process.process import abProcess
 from redis.client import PubSub
@@ -7,6 +6,7 @@ from redis.client import PubSub
 from common.event_bus.listener.listener import abListener
 from define.define import E_COMMUNICATION_TYPE
 from protocol.protocol_meta import ProtocolMeta
+from protocol.protocol_wrapper import ProtocolWrapper
 
 
 class ImdgListener(abListener):
@@ -17,17 +17,17 @@ class ImdgListener(abListener):
     def action(self) -> None:
         for message in self._pubsub.listen():
             if message['type'] == 'message':
-                message_data = message["data"].decode("utf-8")
-                json_data = json.loads(message_data)
-                protocol_id = json_data['header']['protocol_id']
-                receiver = json_data['header']['receiver']
+                envelope = message["data"].decode("utf-8")
+                splits = ProtocolWrapper.get_split_protocol_message(envelope)
+                receiver = ProtocolWrapper.get_receiver_with_splits(splits)
 
                 if self._parent_process.is_ignore(E_COMMUNICATION_TYPE.IMDG, receiver):
                     continue
 
-                packet = ProtocolMeta.get_json_decoder(protocol_id)(message_data)
-                ProtocolMeta.get_receive_handler(protocol_id, receiver)(self._parent_process, packet)
+                wrapper, packet = ProtocolWrapper.decode_protocol_wrapper_with_message_protocol(envelope)
+                ProtocolMeta.get_receive_handler(wrapper.protocol_id, receiver)(
+                    self._parent_process, wrapper, packet
+                )
 
         time.sleep(0.001)
         pass
-

--- a/src/common/event_bus/listener/stream_listener.py
+++ b/src/common/event_bus/listener/stream_listener.py
@@ -1,4 +1,3 @@
-import json
 import socket
 
 import redis
@@ -9,6 +8,7 @@ from python_library.process.process import abProcess
 from common.event_bus.listener.listener import abListener
 from config.project_config import ProjectConfig
 from protocol.protocol_meta import ProtocolMeta
+from protocol.protocol_wrapper import ProtocolWrapper
 
 
 class StreamListener(abListener):
@@ -42,12 +42,12 @@ class StreamListener(abListener):
         )
         for _, entries in (messages or []):
             for msg_id, fields in entries:
-                message_data = fields[b"data"].decode("utf-8")
-                json_data = json.loads(message_data)
-                protocol_id = json_data["header"]["protocol_id"]
-                receiver = json_data["header"]["receiver"]
-                packet = ProtocolMeta.get_json_decoder(protocol_id)(message_data)
-                ProtocolMeta.get_receive_handler(protocol_id, receiver)(
-                    self._parent_process, packet
+                envelope = fields[b"data"].decode("utf-8")
+                splits = ProtocolWrapper.get_split_protocol_message(envelope)
+                receiver = ProtocolWrapper.get_receiver_with_splits(splits)
+
+                wrapper, packet = ProtocolWrapper.decode_protocol_wrapper_with_message_protocol(envelope)
+                ProtocolMeta.get_receive_handler(wrapper.protocol_id, receiver)(
+                    self._parent_process, wrapper, packet
                 )
                 self._redis.xack(self._stream_name, self._group_name, msg_id)

--- a/src/protocol/protocol_meta.py
+++ b/src/protocol/protocol_meta.py
@@ -7,11 +7,12 @@ from typing import Any, Callable, Dict, Mapping, ClassVar
 from python_library.process.process import abProcess
 
 from protocol.message.packet import IPacket
+from protocol.protocol_wrapper import ProtocolWrapper
 
 ReceiverKey = Any
 FactoryFn = Callable[..., IPacket]
 DecoderFn = Callable[[Any], IPacket]
-HandlerFn = Callable[[abProcess, IPacket], Any]
+HandlerFn = Callable[[abProcess, ProtocolWrapper, IPacket], Any]
 
 
 class E_PROTOCOL_ID(Enum):
@@ -86,8 +87,8 @@ class ProtocolMeta:
                 ),
                 decoder=PDPlayableListReq.from_json,
                 receive_handlers={
-                    E_CATE.REST_SERVER: lambda process, packet: SocketIOServer.playable_list_request(
-                        process, packet
+                    E_CATE.REST_SERVER: lambda process, wrapper, packet: SocketIOServer.playable_list_request(
+                        process, wrapper, packet
                     ),
                 },
             ),
@@ -108,11 +109,11 @@ class ProtocolMeta:
                 ),
                 decoder=PlayableListReq.from_json,
                 receive_handlers={
-                    E_CATE.MESSAGE_BRIDGE: lambda process, packet: (
-                        MessageBridgeProcess.playable_list_request(process, packet)
+                    E_CATE.MESSAGE_BRIDGE: lambda process, wrapper, packet: (
+                        MessageBridgeProcess.playable_list_request(process, wrapper, packet)
                     ),
-                    E_CATE.DOWNLOADER: lambda process, packet: (
-                        DownloaderManager.playable_list_request(process, packet)
+                    E_CATE.DOWNLOADER: lambda process, wrapper, packet: (
+                        DownloaderManager.playable_list_request(process, wrapper, packet)
                     ),
                 },
             ),
@@ -132,8 +133,8 @@ class ProtocolMeta:
                 ),
                 decoder=InrPlayableListReq.from_json,
                 receive_handlers={
-                    E_CATE.DOWNLOADER: lambda process, packet: (
-                        DownloaderModule.playable_list_request(process, packet)
+                    E_CATE.DOWNLOADER: lambda process, wrapper, packet: (
+                        DownloaderModule.playable_list_request(process, wrapper, packet)
                     )
                 },
             ),

--- a/src/protocol/protocol_wrapper.py
+++ b/src/protocol/protocol_wrapper.py
@@ -6,7 +6,7 @@ from utils.jsonpickle_util import JsonpickleUtil
 from utils.string_builder import StringBuilder
 from utils.time_string_fit import TimeStringFit, E_TIMEFORMAT
 
-# TODO: 정리할것
+
 class ProtocolWrapper:
     DELIM_CHAR = "|:|"
 
@@ -54,20 +54,43 @@ class ProtocolWrapper:
         return field_key + "_" + f"{seq:08}"
 
     @staticmethod
-    def get_protocol_wrapper(protocol_message_object):
+    def get_protocol_wrapper(protocol_message_object: IPacket) -> "ProtocolWrapper":
         message_id = ProtocolWrapper.get_sequence_id_now()
         return ProtocolWrapper(message_id, protocol_message_object)
 
     @staticmethod
-    def decode_protocol_wrapper(protocol_message_string):
-        s = protocol_message_string.split(ProtocolWrapper.DELIM_CHAR)
+    def get_split_protocol_message(protocol_message_string: str) -> list[str]:
+        return protocol_message_string.split(ProtocolWrapper.DELIM_CHAR)
 
-        communication_type = s[ProtocolWrapper.E_PROTOCOL_MESSAGE_ELE.COMMUNICATION_TYPE]
-        message_id = s[ProtocolWrapper.E_PROTOCOL_MESSAGE_ELE.MESSAGE_ID]
-        protocol_id = s[ProtocolWrapper.E_PROTOCOL_MESSAGE_ELE.PROTOCOL_ID]
-        message_direction = s[ProtocolWrapper.E_PROTOCOL_MESSAGE_ELE.MESSAGE_DIRECTION]
-        sender = s[ProtocolWrapper.E_PROTOCOL_MESSAGE_ELE.SENDER]
-        receiver = s[ProtocolWrapper.E_PROTOCOL_MESSAGE_ELE.RECEIVER]
-        protocol_message = s[ProtocolWrapper.E_PROTOCOL_MESSAGE_ELE.PROTOCOL_MESSAGE]
+    @staticmethod
+    def get_communication_type_with_splits(splits: list[str]) -> str:
+        return splits[ProtocolWrapper.E_PROTOCOL_MESSAGE_ELE.COMMUNICATION_TYPE]
 
-        return communication_type, protocol_id, message_id, message_direction, sender, receiver, protocol_message
+    @staticmethod
+    def get_protocol_id_with_splits(splits: list[str]) -> str:
+        return splits[ProtocolWrapper.E_PROTOCOL_MESSAGE_ELE.PROTOCOL_ID]
+
+    @staticmethod
+    def get_receiver_with_splits(splits: list[str]) -> str:
+        return splits[ProtocolWrapper.E_PROTOCOL_MESSAGE_ELE.RECEIVER]
+
+    @staticmethod
+    def decode_protocol_wrapper(protocol_message_string: str) -> "ProtocolWrapper":
+        wrapper, _ = ProtocolWrapper.decode_protocol_wrapper_with_message_protocol(protocol_message_string)
+        return wrapper
+
+    @staticmethod
+    def decode_protocol_wrapper_with_message_protocol(
+        protocol_message_string: str,
+    ) -> tuple["ProtocolWrapper", IPacket]:
+        from protocol.protocol_meta import ProtocolMeta
+
+        splits = ProtocolWrapper.get_split_protocol_message(protocol_message_string)
+
+        message_id = splits[ProtocolWrapper.E_PROTOCOL_MESSAGE_ELE.MESSAGE_ID]
+        protocol_id = splits[ProtocolWrapper.E_PROTOCOL_MESSAGE_ELE.PROTOCOL_ID]
+        protocol_message_json = splits[ProtocolWrapper.E_PROTOCOL_MESSAGE_ELE.PROTOCOL_MESSAGE]
+
+        packet = ProtocolMeta.get_json_decoder(protocol_id)(protocol_message_json)
+        wrapper = ProtocolWrapper(message_id, packet)
+        return wrapper, packet


### PR DESCRIPTION
## Summary
- IMDG/Stream 송수신 메시지 포맷을 raw IPacket JSON에서 envelope 문자열(`COMM|:|MSG_ID|:|DIR|:|PROTO_ID|:|SENDER|:|RECEIVER|:|<payload>`)로 전환. 라우팅 정보(receiver, protocol_id 등)를 JSON 파싱 없이 split만으로 추출
- `ProtocolWrapper` 보강: typed `decode_protocol_wrapper_with_message_protocol(string) -> (ProtocolWrapper, IPacket)` + 라우팅용 split helper 추가. decoder dispatch는 `ProtocolMeta.get_json_decoder` 위임 (slim wrapper, 별도 DecodeHandler dict 안 둠)
- 핸들러 시그니처를 `(process, packet)` → `(process, wrapper, packet)`으로 통일. transport-level 정보(message_id 등)도 핸들러가 접근 가능
- WebSocket 입구는 JSON 유지하되 내부에서 wrapper로 감싸 핸들러로 전달 (외부 클라이언트는 envelope 모름)
- pyright 26 → 26 (사전 결함 그대로, 새 오류 0)

## Related Issue
close #30