### PR TITLE
[fix] #35 DownloaderManager/Module action() override 제거 + scripts/dev.sh 추가

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")/.."
+
+# 백그라운드로 3개 서버 실행
+uv run python src/rest_server_app.py &
+PID_REST=$!
+uv run python src/message_bridge_app.py &
+PID_MB=$!
+uv run python src/downloader_app.py &
+PID_DL=$!
+
+# 종료 시 정리
+trap "kill $PID_REST $PID_MB $PID_DL 2>/dev/null || true" EXIT
+
+# 서버 startup 대기
+sleep 2
+
+# 테스트 실행
+uv run pytest tests/test_client/test_client.py -s

--- a/src/app/downloader/process/downloader_manager.py
+++ b/src/app/downloader/process/downloader_manager.py
@@ -1,4 +1,3 @@
-from common.event_bus.listener.stream_listener import StreamListener
 from common.process.imdg_bus_process import IImdgBusProcess, ImdgBusProcess
 from protocol.message.message import IMessage
 from protocol.protocol_wrapper import ProtocolWrapper
@@ -7,16 +6,7 @@ from protocol.protocol_wrapper import ProtocolWrapper
 class DownloaderManager(ImdgBusProcess):
     def __init__(self, app_name, process_name):
         super().__init__(app_name, process_name)
-        self._stream_listener: StreamListener | None = None
-
-    def on_init(self):
-        super().on_init()
-        self._stream_listener = StreamListener(self)
-        self._stream_listener.start()
 
     @staticmethod
     def playable_list_request(process: IImdgBusProcess, wrapper: ProtocolWrapper, packet: IMessage):
-        pass
-
-    def action(self) -> None:
         pass

--- a/src/app/downloader/process/downloader_module.py
+++ b/src/app/downloader/process/downloader_module.py
@@ -13,6 +13,3 @@ class DownloaderModule(QueueControlProcess):
     @staticmethod
     def playable_list_request(process: abProcess, wrapper: ProtocolWrapper, packet: IMessage):
         pass
-
-    def action(self) -> None:
-        pass


### PR DESCRIPTION
## Summary
- DownloaderManager / DownloaderModule이 `def action(self) -> None: pass`로 부모 `StepProcess.action()` lifecycle을 override해서 `on_init`이 호출되지 않던 버그 수정 — IMDG 메시지 수신 가능해짐
- DownloaderManager의 사용 안 하는 `StreamListener` 의존 + 관련 on_init 정리
- 로컬 통합테스트용 `scripts/dev.sh` 추가 — 4개 앱 동시 실행(&) + trap 정리 + pytest

## Related Issue
close #35