### PR TITLE
[feat] #41 InnerQueueBus에 send_message_(req_)inner_queue 헬퍼 추가

### DIFF
--- a/src/common/event_bus/inner_queue_bus.py
+++ b/src/common/event_bus/inner_queue_bus.py
@@ -9,5 +9,23 @@ class InnerQueueBus(EventBus):
         super().__init__(_parent_process)
         self.listener = InnerQueueListener(_parent_process)
 
+    def send_message_inner_queue(self, receiver_process_name: str, message: str) -> None:
+        self._parent_process.push_shared_queue(receiver_process_name, message)
 
-    pass
+    def send_message_req_inner_queue(
+        self,
+        protocol_id,
+        receiver_process_name: str,
+        *args,
+    ) -> None:
+        from protocol.protocol_meta import ProtocolMeta
+        from protocol.protocol_owner import ProtocolOwner
+        from protocol.protocol_wrapper import ProtocolWrapper
+
+        app_name = self._parent_process.get_app_name()
+        sender = ProtocolOwner.build(app_name, self._parent_process.name)
+        receiver = ProtocolOwner.build(app_name, receiver_process_name)
+        factory = ProtocolMeta.get_protocol_factory(protocol_id)
+        packet = factory(sender, receiver, *args)
+        envelope = ProtocolWrapper.get_protocol_wrapper(packet).get_protocol_packet_message()
+        self.send_message_inner_queue(receiver_process_name, envelope)

--- a/src/common/process/queue_control_process.py
+++ b/src/common/process/queue_control_process.py
@@ -9,17 +9,30 @@ class QueueControlProcess(StepProcess):
     def __init__(self, app_name: str, process_name: str) -> None:
         super().__init__(app_name, process_name)
 
-        self._innerQueueBus = None
+        self._inner_queue_bus = None
         self._handler: dict[E_PROTOCOL_ID, Mapping[ReceiverKey, HandlerFn]] | None = None
 
     def on_init(self):
-        self._innerQueueBus=InnerQueueBus(self)
-        self._innerQueueBus.start()
+        self._inner_queue_bus=InnerQueueBus(self)
+        self._inner_queue_bus.start()
         pass
 
     def on_register_handler(self, handler: dict[E_PROTOCOL_ID, Mapping[ReceiverKey, HandlerFn]]):
         self._handler = handler
         pass
+
+    def send_message_inner_queue(self, receiver_process_name: str, message: str) -> None:
+        assert self._inner_queue_bus is not None
+        self._inner_queue_bus.send_message_inner_queue(receiver_process_name, message)
+
+    def send_message_req_inner_queue(
+        self,
+        protocol_id,
+        receiver_process_name: str,
+        *args,
+    ) -> None:
+        assert self._inner_queue_bus is not None
+        self._inner_queue_bus.send_message_req_inner_queue(protocol_id, receiver_process_name, *args)
 
     def on_proc_once(self):
         pass


### PR DESCRIPTION
## Summary
- `InnerQueueBus.send_message_inner_queue(receiver, message)` — 내부 큐 raw push 메서드 추가
- `InnerQueueBus.send_message_req_inner_queue(protocol_id, receiver, *args)` — factory + ProtocolWrapper envelope을 거쳐 raw 헬퍼로 위임
- `QueueControlProcess`에서 두 메서드 모두 public으로 위임 노출 (ImdgBus/ImdgBusProcess와 1:1 대응)
- `_innerQueueBus` → `_inner_queue_bus` 네이밍 정리

## Related Issue
close #41