### PR TITLE
[feat] #50 InnerQueue/IMDG 송수신 패킷 로깅 추가

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,4 +41,4 @@ build-backend = "hatchling.build"
 packages = ["src"]
 
 [tool.uv.sources]
-python-library = { git = "ssh://git@personal-github/Sinminbeom/python-library.git", tag = "v2.11.0" }
+python-library = { git = "ssh://git@personal-github/Sinminbeom/python-library.git", tag = "v2.11.1" }

--- a/src/common/event_bus/imdg_bus.py
+++ b/src/common/event_bus/imdg_bus.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import redis
 from redis.client import Redis, PubSub
 
+from python_library.logger.app_logger import AppLogger
+
 from common.event_bus.event_bus import abEventBus
 from common.event_bus.listener.imdg_listener import ImdgListener
 from common.process.imdg_bus_process import ImdgBusProcess
 from config.project_config import ProjectConfig
-from protocol.message.message import ResponseInfo
+from protocol.message.message import IMessage, ResponseInfo
+from protocol.protocol_wrapper import ProtocolWrapper
 
 
 class ImdgBus(abEventBus[ImdgBusProcess]):
@@ -25,18 +28,24 @@ class ImdgBus(abEventBus[ImdgBusProcess]):
     def send_message_imdg_queue(self, _message: str) -> None:
         self._imdg.publish(self._channel_name, _message)
 
+    def _wrap_and_send(self, packet: IMessage) -> None:
+        wrapper = ProtocolWrapper.get_protocol_wrapper(packet)
+        envelope = wrapper.get_protocol_packet_message()
+        log = AppLogger.instance()
+        log.info(f"[IMDG SEND] channel={self._channel_name} {wrapper.summary(packet)}")
+        log.debug(f"[IMDG SEND payload] {envelope}")
+        self.send_message_imdg_queue(envelope)
+
     def send_message_req_imdg_queue(self, protocol_id, receiver: str, *args) -> None:
         from protocol.protocol_meta import ProtocolMeta
         from protocol.protocol_owner import ProtocolOwner
-        from protocol.protocol_wrapper import ProtocolWrapper
 
         sender = ProtocolOwner.build(
             self._parent_process.get_app_name(), self._parent_process.name
         )
         factory = ProtocolMeta.get_protocol_factory(protocol_id)
         packet = factory(sender, receiver, *args)
-        envelope = ProtocolWrapper.get_protocol_wrapper(packet).get_protocol_packet_message()
-        self.send_message_imdg_queue(envelope)
+        self._wrap_and_send(packet)
 
     def send_message_rep_imdg_queue(
         self,
@@ -47,12 +56,10 @@ class ImdgBus(abEventBus[ImdgBusProcess]):
     ) -> None:
         from protocol.protocol_meta import ProtocolMeta
         from protocol.protocol_owner import ProtocolOwner
-        from protocol.protocol_wrapper import ProtocolWrapper
 
         sender = ProtocolOwner.build(
             self._parent_process.get_app_name(), self._parent_process.name
         )
         factory = ProtocolMeta.get_protocol_factory(protocol_id)
         packet = factory(sender, receiver, *args, response=response)
-        envelope = ProtocolWrapper.get_protocol_wrapper(packet).get_protocol_packet_message()
-        self.send_message_imdg_queue(envelope)
+        self._wrap_and_send(packet)

--- a/src/common/event_bus/inner_queue_bus.py
+++ b/src/common/event_bus/inner_queue_bus.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from python_library.logger.app_logger import AppLogger
+
 from common.event_bus.event_bus import abEventBus
 from common.event_bus.listener.inner_queue_listener import InnerQueueListener
 from common.process.queue_control_process import QueueControlProcess
-from protocol.message.message import ResponseInfo
+from protocol.message.message import IMessage, ResponseInfo
+from protocol.protocol_wrapper import ProtocolWrapper
 
 
 class InnerQueueBus(abEventBus[QueueControlProcess]):
@@ -14,6 +17,14 @@ class InnerQueueBus(abEventBus[QueueControlProcess]):
     def send_message_inner_queue(self, receiver_process_name: str, message: str) -> None:
         self._parent_process.push_shared_queue(receiver_process_name, message)
 
+    def _wrap_and_send(self, receiver_process_name: str, packet: IMessage) -> None:
+        wrapper = ProtocolWrapper.get_protocol_wrapper(packet)
+        envelope = wrapper.get_protocol_packet_message()
+        log = AppLogger.instance()
+        log.info(f"[IQ SEND] {wrapper.summary(packet)}")
+        log.debug(f"[IQ SEND payload] {envelope}")
+        self.send_message_inner_queue(receiver_process_name, envelope)
+
     def send_message_req_inner_queue(
         self,
         protocol_id,
@@ -22,15 +33,13 @@ class InnerQueueBus(abEventBus[QueueControlProcess]):
     ) -> None:
         from protocol.protocol_meta import ProtocolMeta
         from protocol.protocol_owner import ProtocolOwner
-        from protocol.protocol_wrapper import ProtocolWrapper
 
         app_name = self._parent_process.get_app_name()
         sender = ProtocolOwner.build(app_name, self._parent_process.name)
         receiver = ProtocolOwner.build(app_name, receiver_process_name)
         factory = ProtocolMeta.get_protocol_factory(protocol_id)
         packet = factory(sender, receiver, *args)
-        envelope = ProtocolWrapper.get_protocol_wrapper(packet).get_protocol_packet_message()
-        self.send_message_inner_queue(receiver_process_name, envelope)
+        self._wrap_and_send(receiver_process_name, packet)
 
     def broadcast_message_req_inner_queue(
         self,
@@ -51,12 +60,10 @@ class InnerQueueBus(abEventBus[QueueControlProcess]):
     ) -> None:
         from protocol.protocol_meta import ProtocolMeta
         from protocol.protocol_owner import ProtocolOwner
-        from protocol.protocol_wrapper import ProtocolWrapper
 
         app_name = self._parent_process.get_app_name()
         sender = ProtocolOwner.build(app_name, self._parent_process.name)
         receiver = ProtocolOwner.build(app_name, receiver_process_name)
         factory = ProtocolMeta.get_protocol_factory(protocol_id)
         packet = factory(sender, receiver, *args, response=response)
-        envelope = ProtocolWrapper.get_protocol_wrapper(packet).get_protocol_packet_message()
-        self.send_message_inner_queue(receiver_process_name, envelope)
+        self._wrap_and_send(receiver_process_name, packet)

--- a/src/common/event_bus/listener/imdg_listener.py
+++ b/src/common/event_bus/listener/imdg_listener.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 
+from python_library.logger.app_logger import AppLogger
 from redis.client import PubSub
 
 from common.event_bus.listener.listener import abListener
@@ -27,6 +28,11 @@ class ImdgListener(abListener[ImdgBusProcess]):
                     continue
 
                 wrapper, packet = ProtocolWrapper.decode_protocol_wrapper_with_message_protocol(envelope)
+
+                log = AppLogger.instance()
+                log.info(f"[IMDG RECV] {wrapper.summary(packet)}")
+                log.debug(f"[IMDG RECV payload] {envelope}")
+
                 ProtocolMeta.get_receive_handler(wrapper.protocol_id, receiver)(
                     self._parent_process, wrapper, packet
                 )

--- a/src/common/event_bus/listener/inner_queue_listener.py
+++ b/src/common/event_bus/listener/inner_queue_listener.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import time
 
+from python_library.logger.app_logger import AppLogger
+
 from common.event_bus.listener.listener import abListener
 from common.process.queue_control_process import QueueControlProcess
 from protocol.protocol_meta import ProtocolMeta
@@ -22,6 +24,10 @@ class InnerQueueListener(abListener[QueueControlProcess]):
         receiver = ProtocolWrapper.get_receiver_with_splits(splits)
 
         wrapper, packet = ProtocolWrapper.decode_protocol_wrapper_with_message_protocol(envelope)
+
+        log = AppLogger.instance()
+        log.info(f"[IQ RECV] {wrapper.summary(packet)}")
+        log.debug(f"[IQ RECV payload] {envelope}")
 
         # 1. 개별 핸들러 (응답마다 1회)
         ProtocolMeta.get_receive_handler(wrapper.protocol_id, receiver)(

--- a/src/protocol/protocol_wrapper.py
+++ b/src/protocol/protocol_wrapper.py
@@ -1,7 +1,7 @@
 from enum import IntEnum
 
 from define.define import E_COMMUNICATION_TYPE
-from protocol.message.message import IMessage
+from protocol.message.message import E_PROTOCOL_MESSAGE_DIRECTION, IMessage
 from utils.string_builder import StringBuilder
 from utils.time_string_fit import TimeStringFit, E_TIMEFORMAT
 
@@ -32,6 +32,14 @@ class ProtocolWrapper:
         self.receiver = protocol_message.receiver
         self.protocol_message = protocol_message
         self.message_id = message_id
+
+    def summary(self, packet: IMessage | None = None) -> str:
+        direction = E_PROTOCOL_MESSAGE_DIRECTION(int(self.message_direction)).name
+        base = f"proto={self.protocol_id} dir={direction} {self.sender}->{self.receiver}"
+        response = getattr(packet, "response", None) if packet is not None else None
+        if response is not None:
+            base += f" code={response.code}"
+        return base
 
     def get_protocol_packet_message(self) -> str:
         sb = StringBuilder()

--- a/uv.lock
+++ b/uv.lock
@@ -428,7 +428,7 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.128.0" },
     { name = "jsonpickle", specifier = ">=4.1.1" },
-    { name = "python-library", git = "ssh://git@personal-github/Sinminbeom/python-library.git?tag=v2.11.0" },
+    { name = "python-library", git = "ssh://git@personal-github/Sinminbeom/python-library.git?tag=v2.11.1" },
     { name = "python-socketio", extras = ["client"], specifier = ">=5.16.0" },
     { name = "redis", specifier = ">=7.1.0" },
     { name = "requests", specifier = ">=2.32.5" },
@@ -854,8 +854,8 @@ wheels = [
 
 [[package]]
 name = "python-library"
-version = "2.11.0"
-source = { git = "ssh://git@personal-github/Sinminbeom/python-library.git?tag=v2.11.0#ce4b8b8cfd24b018d38b235522e939f91c4823a1" }
+version = "2.11.1"
+source = { git = "ssh://git@personal-github/Sinminbeom/python-library.git?tag=v2.11.1#247145d828082fc5557965ba0885a0d2009a5626" }
 dependencies = [
     { name = "argon2-cffi" },
     { name = "boto3" },


### PR DESCRIPTION
## Summary
- `ProtocolWrapper.summary()` 한 줄 요약 헬퍼 추가 (proto / dir / sender→receiver / response.code)
- InnerQueueBus 송신, InnerQueueListener 수신에 INFO 한 줄 + DEBUG payload 로깅 추가
- ImdgBus 송신, ImdgListener 수신에 INFO 한 줄 + DEBUG payload 로깅 추가 (channel 정보 포함)
- 송신 헬퍼 `_wrap_and_send` 추출로 wrap → log → send 흐름 단일화
- AppLogger 호출은 Singleton 패턴에 맞춰 `AppLogger.instance()` 사용
- python-library 의존성 v2.11.0 -> v2.11.1
- StreamBus는 protocol 패킷 구조가 아니라 본 PR에서 제외 (별도 Task로 분리 가능)

## Related Issues
- close #50