### PR TITLE
[fix] #52 AppLogger logger config path를 logging.conf로 수정

### DIFF
--- a/src/common/process/app_process.py
+++ b/src/common/process/app_process.py
@@ -12,7 +12,7 @@ class AppProcess(QueueProcess[str]):
         self._app_name = app_name
 
     def _set_config(self) -> None:
-        AppLogger.set_config(ProjectConfig.DEFAULT_CONFIG_PATH, self.name)
+        AppLogger.set_config(ProjectConfig.DEFAULT_LOGGING_CONFIG_PATH, self.name)
         ProjectConfig.set_config(ProjectConfig.DEFAULT_CONFIG_PATH)
 
     def get_app_name(self) -> str:

--- a/src/config/project_config.py
+++ b/src/config/project_config.py
@@ -4,6 +4,7 @@ from python_library.define.enum import IENUM
 
 class ProjectConfig(AppConfig):
     DEFAULT_CONFIG_PATH = "./conf/application.conf"
+    DEFAULT_LOGGING_CONFIG_PATH = "./conf/logging.conf"
 
     class E_CATE_TYPE(IENUM):
         COMMON = "COOMON"


### PR DESCRIPTION
## Summary
- AppProcess._set_config가 application.conf를 logger fileConfig로 잘못 넘겨 KeyError: 'formatters' 발생하던 것 수정
- ProjectConfig.DEFAULT_LOGGING_CONFIG_PATH 상수 추가
- AppLogger.set_config가 logging.conf를 사용하도록 변경

## Related Issues
- close #52