### PR TITLE
[refactor] #54 nested dataclass 자동 복원 — base 클래스 generic 직렬화 helper 도입

### DIFF
--- a/src/app/downloader/process/manager/manager.py
+++ b/src/app/downloader/process/manager/manager.py
@@ -5,7 +5,7 @@ from typing import Optional
 from common.process.imdg_bus_process import ImdgBusProcess
 from protocol.message.message import IMessage
 from protocol.protocol_wrapper import ProtocolWrapper
-from protocol.section_element import SectionElement, SectionElementContainer
+from protocol.section_element import SectionElementContainer
 
 from app.downloader.process.manager.state import (
     E_DOWNLOADER_MANAGER_STATE,
@@ -92,21 +92,16 @@ class DownloaderManager(ImdgBusProcess):
                 process._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.WAIT)
             return
 
-        # 2) COMPLEATE — packets에서 sensor별 sections 복원 + 1초 grid 펼치기 + N-way 교집합
+        # 2) COMPLEATE — packets에서 sensor별 sections를 1초 grid로 펼치기 + N-way 교집합.
+        # base 직렬화 helper가 from_json 시점에 section_list를 list[SectionElement]로 복원하므로
+        # 더이상 dict 분기 필요 없음.
         one_dim_lists: list[list[str]] = []
         sensor_ids: list[str] = []
         for packet in packets:
             assert isinstance(packet, InrPlayableListRep)
             sensor_ids.append(packet.sensor_id)
-
-            elements: list[SectionElement] = []
-            for raw in packet.section_list:
-                if isinstance(raw, SectionElement):
-                    elements.append(raw)
-                elif isinstance(raw, dict):
-                    elements.append(SectionElement(**raw))
             one_dim_lists.append(
-                SectionElementContainer(elements).convert_one_dimensional_list()
+                SectionElementContainer(packet.section_list).convert_one_dimensional_list()
             )
 
         playable_list = SectionElementContainer.calculate_intersection(*one_dim_lists)

--- a/src/protocol/message/external/external.py
+++ b/src/protocol/message/external/external.py
@@ -1,7 +1,7 @@
-import json
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
 from protocol.message.message import IMessage, E_PROTOCOL_MESSAGE_DIRECTION
+from protocol.serialization import DataclassSerializer
 
 
 @dataclass
@@ -13,11 +13,11 @@ class pdPacket(IMessage):
     message_direction: E_PROTOCOL_MESSAGE_DIRECTION = E_PROTOCOL_MESSAGE_DIRECTION.REQUEST
 
     def to_json(self) -> str:
-        return json.dumps(asdict(self))
+        return DataclassSerializer.to_json(self)
 
     @classmethod
     def from_json(cls, json_string: str):
-        return cls(**json.loads(json_string))
+        return DataclassSerializer.from_json(cls, json_string)
 
 
 @dataclass

--- a/src/protocol/message/external/ui/playable_list.py
+++ b/src/protocol/message/external/ui/playable_list.py
@@ -1,5 +1,4 @@
-import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 
 from protocol.message.external.external import pdPacket, pdResponsePacket
 from protocol.message.external.ui.section_element import PDSectionElement
@@ -17,15 +16,4 @@ class PDPlayableListReq(pdPacket):
 class PDPlayableListRep(pdResponsePacket):
     sensor_id_list: list[str] = field(default_factory=list)
     section_list: list[PDSectionElement] = field(default_factory=list)
-
-    def to_json(self) -> str:
-        d = asdict(self)
-        d["section_list"] = [asdict(s) for s in self.section_list]
-        return json.dumps(d)
-
-    @classmethod
-    def from_json(cls, json_string: str) -> "PDPlayableListRep":
-        d = json.loads(json_string)
-        if d.get("section_list") is not None:
-            d["section_list"] = [PDSectionElement(**s) for s in d["section_list"]]
-        return cls(**d)
+    # to_json/from_json override 불필요 — pdPacket base가 list[Dataclass] 자동 복원

--- a/src/protocol/message/imdg/playable_list.py
+++ b/src/protocol/message/imdg/playable_list.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 
 from protocol.message.imdg.imdg import abImdgRequestMessage, abImdgResponseMessage
+from protocol.section_element import SectionElement
 
 
 @dataclass
@@ -14,4 +15,4 @@ class PlayableListReq(abImdgRequestMessage):
 @dataclass
 class PlayableListRep(abImdgResponseMessage):
     sensor_id_list: list[str] = field(default_factory=list)
-    section_list: list = field(default_factory=list)
+    section_list: list[SectionElement] = field(default_factory=list)

--- a/src/protocol/message/message.py
+++ b/src/protocol/message/message.py
@@ -1,8 +1,8 @@
-import json
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from enum import IntEnum
 
 from define.define import E_COMMUNICATION_TYPE
+from protocol.serialization import DataclassSerializer
 
 
 class IMessage:
@@ -41,11 +41,8 @@ class abProtocolMessage(IMessage):
     response: ResponseInfo | None = None
 
     def to_json(self) -> str:
-        return json.dumps(asdict(self))
+        return DataclassSerializer.to_json(self)
 
     @classmethod
     def from_json(cls, json_string: str):
-        d = json.loads(json_string)
-        if d.get("response") is not None:
-            d["response"] = ResponseInfo(**d["response"])
-        return cls(**d)
+        return DataclassSerializer.from_json(cls, json_string)

--- a/src/protocol/message/process/playable_list.py
+++ b/src/protocol/message/process/playable_list.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 
 from protocol.message.process.process import abProcessRequestMessage, abProcessResponseMessage
+from protocol.section_element import SectionElement
 
 
 @dataclass
@@ -13,4 +14,4 @@ class InrPlayableListReq(abProcessRequestMessage):
 @dataclass
 class InrPlayableListRep(abProcessResponseMessage):
     sensor_id: str = ""
-    section_list: list = field(default_factory=list)
+    section_list: list[SectionElement] = field(default_factory=list)

--- a/src/protocol/serialization.py
+++ b/src/protocol/serialization.py
@@ -1,0 +1,78 @@
+"""dataclass 메시지의 generic JSON 직렬화/역직렬화."""
+from __future__ import annotations
+
+import json
+import typing
+from dataclasses import asdict, is_dataclass
+from typing import Any, Type, TypeVar
+
+T = TypeVar("T")
+
+
+class DataclassSerializer:
+    """dataclass 메시지의 generic JSON 직렬화/역직렬화 유틸.
+
+    `asdict`로 to_json은 평탄하지만, from_json 시 nested dataclass 필드를 자동 복원하지 않음
+    (예: `list[SectionElement]`이 JSON roundtrip 후 `list[dict]`로 남음). 이 유틸이
+    `typing.get_type_hints` 인트로스펙션으로 nested 필드를 재귀 복원한다.
+
+    지원 필드 타입:
+      - `list[Dataclass]`           → 각 dict를 Dataclass로 복원
+      - `Optional[Dataclass]` (= `X | None`) → dict면 Dataclass로 복원
+      - `Dataclass` (직접)          → dict면 Dataclass로 복원
+      - primitive (str/int/list[str] 등) → 그대로 통과
+    """
+
+    @staticmethod
+    def to_json(obj: Any) -> str:
+        """dataclass 인스턴스를 JSON 문자열로. asdict가 nested dataclass도 재귀 dict화."""
+        return json.dumps(asdict(obj))
+
+    @staticmethod
+    def from_json(target_cls: Type[T], json_string: str) -> T:
+        """JSON 문자열을 dataclass 인스턴스로. nested dataclass 필드 자동 복원."""
+        return DataclassSerializer._reconstruct_dataclass(target_cls, json.loads(json_string))
+
+    @staticmethod
+    def _reconstruct_dataclass(target_cls: Any, d: dict) -> Any:
+        hints = typing.get_type_hints(target_cls)
+        for field_name, field_type in hints.items():
+            if field_name not in d or d[field_name] is None:
+                continue
+            d[field_name] = DataclassSerializer._reconstruct_value(field_type, d[field_name])
+        return target_cls(**d)
+
+    @staticmethod
+    def _reconstruct_value(field_type: Any, value: Any) -> Any:
+        origin = typing.get_origin(field_type)
+        args = typing.get_args(field_type)
+
+        # Optional[X] / X | None → 비-None 타입으로 unwrap 후 재귀
+        if origin is typing.Union or DataclassSerializer._is_union_type(origin):
+            non_none_args = [a for a in args if a is not type(None)]
+            if len(non_none_args) == 1:
+                return DataclassSerializer._reconstruct_value(non_none_args[0], value)
+            return value  # 복합 Union은 손대지 않음
+
+        # list[X] → X가 dataclass면 각 요소 복원
+        if origin is list and args:
+            item_type = args[0]
+            if is_dataclass(item_type) and isinstance(value, list):
+                return [
+                    DataclassSerializer._reconstruct_dataclass(item_type, item)
+                    if isinstance(item, dict) else item
+                    for item in value
+                ]
+            return value
+
+        # 직접 dataclass 필드 (예: ResponseInfo)
+        if is_dataclass(field_type) and isinstance(value, dict):
+            return DataclassSerializer._reconstruct_dataclass(field_type, value)
+
+        return value
+
+    @staticmethod
+    def _is_union_type(origin: Any) -> bool:
+        """Python 3.10+ `X | Y` syntax는 typing.Union이 아닌 types.UnionType. 둘 다 처리."""
+        import types
+        return origin is types.UnionType  # noqa: E721


### PR DESCRIPTION
## Summary
- DataclassSerializer 클래스 신규 (protocol/serialization.py) — typing 인트로스펙션으로 list[Dataclass] / Optional[Dataclass] / 직접 Dataclass 필드를 from_json 시점에 자동 재귀 복원
- abProtocolMessage / pdPacket의 to_json/from_json을 DataclassSerializer로 위임 (수동 ResponseInfo 처리 제거)
- PlayableListRep / InrPlayableListRep의 section_list: list (bare) → list[SectionElement] 타입 명시
- PDPlayableListRep의 수동 to_json/from_json override 제거 (base가 자동 처리)
- manager.playable_list_group_response의 dict isinstance 분기 제거 (이제 from_json이 list[SectionElement] 보장)

신규 메시지 클래스 추가 시 직렬화 boilerplate 0. PD/IMDG/Inner 메시지의 직렬화 정책 통일.

## Related Issues
- close #54