### PR TITLE
[fix] #56 AppLogger logger naming hierarchy 적용

### DIFF
--- a/src/common/process/app_process.py
+++ b/src/common/process/app_process.py
@@ -12,7 +12,10 @@ class AppProcess(QueueProcess[str]):
         self._app_name = app_name
 
     def _set_config(self) -> None:
-        AppLogger.set_config(ProjectConfig.DEFAULT_LOGGING_CONFIG_PATH, self.name)
+        AppLogger.set_config(
+            ProjectConfig.DEFAULT_LOGGING_CONFIG_PATH,
+            f"{ProjectConfig.LOGGER_BASE_NAME}.{self.name}",
+        )
         ProjectConfig.set_config(ProjectConfig.DEFAULT_CONFIG_PATH)
 
     def get_app_name(self) -> str:

--- a/src/config/project_config.py
+++ b/src/config/project_config.py
@@ -5,6 +5,7 @@ from python_library.define.enum import IENUM
 class ProjectConfig(AppConfig):
     DEFAULT_CONFIG_PATH = "./conf/application.conf"
     DEFAULT_LOGGING_CONFIG_PATH = "./conf/logging.conf"
+    LOGGER_BASE_NAME = "data-pipeline"
 
     class E_CATE_TYPE(IENUM):
         COMMON = "COOMON"


### PR DESCRIPTION
## Summary
- logger NAME을 `data-pipeline.{process_name}` dotted hierarchy로 변경
- 'data-pipeline' parent logger의 level=DEBUG, console+file handler 자동 상속 → 모든 process에서 INFO/DEBUG 출력 가능
- propagate=0이라 root로 중복 출력 없음
- ProjectConfig.LOGGER_BASE_NAME 상수 추가

## Related Issues
- close #56