### PR TITLE
[feat] #58 Play 패킷 3계층(PD/IMDG/INR) + Streamer 도메인 신설 + ProtocolHandler 중앙화

### DIFF
--- a/src/app/downloader/process/manager/manager.py
+++ b/src/app/downloader/process/manager/manager.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from typing import Optional
 
 from common.process.imdg_bus_process import ImdgBusProcess
+from protocol.inr_protocol_matcher.inr_pair_state import E_PROTOCOL_PAIR_STATE
+from protocol.message.imdg.play import PlayReq, PlayRep
+from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
 from protocol.message.message import IMessage
-from protocol.protocol_wrapper import ProtocolWrapper
+from protocol.message.process.play import InrPlayRep
 from protocol.section_element import SectionElementContainer
 
 from app.downloader.process.manager.state import (
@@ -36,15 +39,14 @@ class DownloaderManager(ImdgBusProcess):
         assert isinstance(current, E_DOWNLOADER_MANAGER_STATE)
         return current
 
-    @staticmethod
-    def playable_list_request(process: DownloaderManager, wrapper: ProtocolWrapper, packet: IMessage):
+    def handle_playable_list_request(self, packet: PlayableListReq) -> None:
         from process_category.enum_category import E_CATE
         from protocol.protocol_meta import E_PROTOCOL_ID
         from protocol.protocol_owner import ProtocolOwner
         from protocol.protocol_code import E_CODE, make_response_info
 
-        if process.get_current_state_id() != E_DOWNLOADER_MANAGER_STATE.WAIT:
-            process.send_message_rep_imdg(
+        if self.get_current_state_id() != E_DOWNLOADER_MANAGER_STATE.WAIT:
+            self.send_message_rep_imdg(
                 E_PROTOCOL_ID.PLAYABLE_LIST_REP,
                 ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE),
                 None,
@@ -53,17 +55,14 @@ class DownloaderManager(ImdgBusProcess):
             )
             return
 
-        if process._state_component is not None:
-            process._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.PLAYABLE, state_param_dto=packet)
+        if self._state_component is not None:
+            self._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.PLAYABLE, state_param_dto=packet)
 
-    @staticmethod
-    def playable_list_response(process: DownloaderManager, wrapper: ProtocolWrapper, packet: IMessage):
-        # 매처 경로(playable_list_group_response)가 모든 후처리를 담당하므로 개별 핸들러는 no-op.
-        # listener가 receive_handlers를 항상 dispatch하므로 빈 stub은 유지 (KeyError 방지).
+    def handle_playable_list_response(self, packet: PlayableListRep) -> None:
+        # 매처 경로(handle_playable_list_group_response)가 후처리 담당 — 개별 handler는 no-op.
         pass
 
-    @staticmethod
-    def playable_list_group_response(process, pair_state, packets):
+    def handle_playable_list_group_response(self, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]) -> None:
         """모든 모듈의 INR_PLAYABLE_LIST_REP 도착 시 매처 인프라가 발화.
 
         교집합 계산 + PLAYABLE_LIST_REP 송신 + DOWNLOAD_READY 전이를 한 곳에서 수행.
@@ -72,7 +71,6 @@ class DownloaderManager(ImdgBusProcess):
           - change_state → 다음 메인 loop frame에 적용되는 reservation
         """
         from process_category.enum_category import E_CATE
-        from protocol.inr_protocol_matcher.inr_pair_state import E_PROTOCOL_PAIR_STATE
         from protocol.message.process.playable_list import InrPlayableListRep
         from protocol.protocol_code import E_CODE, make_response_info
         from protocol.protocol_meta import E_PROTOCOL_ID
@@ -84,12 +82,12 @@ class DownloaderManager(ImdgBusProcess):
 
         # 1) ERROR — INVALID_REQUEST 응답 후 WAIT 복귀
         if pair_state == E_PROTOCOL_PAIR_STATE.ERROR:
-            process.send_message_rep_imdg(
+            self.send_message_rep_imdg(
                 E_PROTOCOL_ID.PLAYABLE_LIST_REP, bridge, None, None,
                 response=make_response_info(E_CODE.INVALID_REQUEST, "module error"),
             )
-            if process._state_component is not None:
-                process._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.WAIT)
+            if self._state_component is not None:
+                self._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.WAIT)
             return
 
         # 2) COMPLEATE — packets에서 sensor별 sections를 1초 grid로 펼치기 + N-way 교집합.
@@ -107,7 +105,7 @@ class DownloaderManager(ImdgBusProcess):
         playable_list = SectionElementContainer.calculate_intersection(*one_dim_lists)
 
         # 3) PLAYABLE_LIST_REP 송신
-        process.send_message_rep_imdg(
+        self.send_message_rep_imdg(
             E_PROTOCOL_ID.PLAYABLE_LIST_REP,
             bridge,
             sensor_ids,
@@ -116,5 +114,11 @@ class DownloaderManager(ImdgBusProcess):
         )
 
         # 4) DOWNLOAD_READY 전이 (reservation — 다음 메인 frame에 적용됨)
-        if process._state_component is not None:
-            process._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.DOWNLOAD_READY)
+        if self._state_component is not None:
+            self._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.DOWNLOAD_READY)
+
+    def handle_play_request(self, packet: PlayReq) -> None:
+        raise NotImplementedError
+
+    def handle_play_response(self, packet: InrPlayRep) -> None:
+        raise NotImplementedError

--- a/src/app/downloader/process/module/module.py
+++ b/src/app/downloader/process/module/module.py
@@ -8,8 +8,8 @@ from python_library.storage.storage import IStorage
 
 from common.process.queue_control_process import QueueControlProcess
 from config.project_config import ProjectConfig
-from protocol.message.message import IMessage
-from protocol.protocol_wrapper import ProtocolWrapper
+from protocol.message.process.play import InrPlayReq
+from protocol.message.process.playable_list import InrPlayableListReq
 
 from app.downloader.process.module.state import (
     E_DOWNLOADER_MODULE_STATE,
@@ -55,24 +55,26 @@ class DownloaderModule(QueueControlProcess):
     def get_storage_prefix(self) -> str:
         return self._storage_prefix
 
-    @staticmethod
-    def playable_list_request(process: DownloaderModule, wrapper: ProtocolWrapper, packet: IMessage):
+    def handle_playable_list_request(self, packet: InrPlayableListReq) -> None:
         from process_category.enum_category import E_CATE
         from protocol.protocol_code import E_CODE, make_response_info
         from protocol.protocol_meta import E_PROTOCOL_ID
 
-        if process.get_current_state_id() != E_DOWNLOADER_MODULE_STATE.WAIT:
-            process.send_message_rep_inner_queue(
+        if self.get_current_state_id() != E_DOWNLOADER_MODULE_STATE.WAIT:
+            self.send_message_rep_inner_queue(
                 E_PROTOCOL_ID.INR_PLAYABLE_LIST_REP,
                 E_CATE.E_DOWNLOADER.E_COMMON.DOWNLOAD_MANAGER,
-                process.name,
+                self.name,
                 [],
                 response=make_response_info(E_CODE.INVALID_REQUEST),
             )
             return
 
-        if process._state_component is not None:
-            process._state_component.change_state(
+        if self._state_component is not None:
+            self._state_component.change_state(
                 E_DOWNLOADER_MODULE_STATE.PLAYABLE,
                 state_param_dto=packet,
             )
+
+    def handle_play_request(self, packet: InrPlayReq) -> None:
+        raise NotImplementedError

--- a/src/app/message_bridge/process/message_bridge_process.py
+++ b/src/app/message_bridge/process/message_bridge_process.py
@@ -1,5 +1,9 @@
-from common.process.imdg_bus_process import IImdgBusProcess, ImdgBusProcess
-from protocol.message.message import IMessage, ResponseInfo
+from __future__ import annotations
+
+from common.process.imdg_bus_process import ImdgBusProcess
+from protocol.message.imdg.play import PlayReq, PlayRep
+from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
+from protocol.message.message import ResponseInfo
 from protocol.protocol_meta import E_PROTOCOL_ID, ProtocolMeta
 from protocol.protocol_wrapper import ProtocolWrapper
 
@@ -8,10 +12,10 @@ class MessageBridgeProcess(ImdgBusProcess):
     def __init__(self, app_name, process_name):
         super().__init__(app_name, process_name)
 
-    @staticmethod
-    def playable_list_request(process: IImdgBusProcess, wrapper: ProtocolWrapper, packet: IMessage):
+    def handle_playable_list_request(self, packet: PlayableListReq) -> None:
         from process_category.enum_category import E_CATE
         from protocol.protocol_owner import ProtocolOwner
+
         sender = ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE)
         receiver = ProtocolOwner.build(E_CATE.DOWNLOADER, E_CATE.E_DOWNLOADER.E_COMMON.DOWNLOAD_MANAGER)
         factory = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PLAYABLE_LIST_REQ)
@@ -24,10 +28,9 @@ class MessageBridgeProcess(ImdgBusProcess):
             packet.end_time,
         )
         envelope = ProtocolWrapper.get_protocol_wrapper(fwd_packet).get_protocol_packet_message()
-        process.send_message_imdg(envelope)
+        self.send_message_imdg(envelope)
 
-    @staticmethod
-    def playable_list_response(process: IImdgBusProcess, wrapper: ProtocolWrapper, packet: IMessage):
+    def handle_playable_list_response(self, packet: PlayableListRep) -> None:
         """DOWNLOADER에서 받은 PLAYABLE_LIST_REP를 PD_PLAYABLE_LIST_REP로 변환해 REST_SERVER로 IMDG 송신."""
         from process_category.enum_category import E_CATE
         from protocol.message.external.ui.section_element import PDSectionElement
@@ -52,7 +55,7 @@ class MessageBridgeProcess(ImdgBusProcess):
         response: ResponseInfo = packet.response or ResponseInfo()
         receiver = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
         factory = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PD_PLAYABLE_LIST_REP)
-        sender = ProtocolOwner.build(process.get_app_name(), process.name)
+        sender = ProtocolOwner.build(self.get_app_name(), self.name)
 
         fwd_packet = factory(
             sender,
@@ -64,4 +67,28 @@ class MessageBridgeProcess(ImdgBusProcess):
             response.reason,
         )
         envelope = ProtocolWrapper.get_protocol_wrapper(fwd_packet).get_protocol_packet_message()
-        process.send_message_imdg(envelope)
+        self.send_message_imdg(envelope)
+
+    def handle_play_request(self, packet: PlayReq) -> None:
+        # PLAY_REQ는 STREAMER도 broadcast로 받으므로 BRIDGE는 forward 불필요 — no-op.
+        pass
+
+    def handle_play_response(self, packet: PlayRep) -> None:
+        """STREAMER → MESSAGE_BRIDGE로 들어온 PLAY_REP를 PD_PLAY_REP로 변환해 REST_SERVER로 IMDG 송신."""
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_owner import ProtocolOwner
+
+        response: ResponseInfo = packet.response or ResponseInfo()
+        receiver = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
+        factory = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PD_PLAY_REP)
+        sender = ProtocolOwner.build(self.get_app_name(), self.name)
+
+        fwd_packet = factory(
+            sender,
+            receiver,
+            response.code,
+            response.code_nm,
+            response.reason,
+        )
+        envelope = ProtocolWrapper.get_protocol_wrapper(fwd_packet).get_protocol_packet_message()
+        self.send_message_imdg(envelope)

--- a/src/app/rest/process/socket_io_process.py
+++ b/src/app/rest/process/socket_io_process.py
@@ -1,6 +1,16 @@
+from __future__ import annotations
+
+import asyncio
+
 from app.rest.websocket_server import SocketIOServer
 from common.process.imdg_bus_process import ImdgBusProcess
 from config.project_config import ProjectConfig
+from protocol.message.external.ui.play import PDPlayReq, PDPlayRep
+from protocol.message.external.ui.playable_list import PDPlayableListReq, PDPlayableListRep
+from protocol.message.message import IMessage
+from protocol.protocol_meta import E_PROTOCOL_ID, ProtocolMeta
+from protocol.protocol_owner import ProtocolOwner
+from protocol.protocol_wrapper import ProtocolWrapper
 
 
 class SocketIOProcess(ImdgBusProcess):
@@ -8,7 +18,6 @@ class SocketIOProcess(ImdgBusProcess):
         super().__init__(app_name, process_name)
 
         self.websocket_server: SocketIOServer | None = None
-        pass
 
     def on_init(self):
         super().on_init()
@@ -18,9 +27,58 @@ class SocketIOProcess(ImdgBusProcess):
 
         self.websocket_server = SocketIOServer(self, bind_ip, bind_port)
         self.websocket_server.start()
-        
 
+    def broadcast_to_clients(self, packet: IMessage) -> None:
+        """IMDG thread에서 받은 PD response를 메인 asyncio loop로 thread-safe하게 emit."""
+        if self.websocket_server is None or self.websocket_server._loop is None:
+            print("[REST] websocket_server / asyncio loop 미초기화 — 응답 drop")
+            return
+        asyncio.run_coroutine_threadsafe(
+            self.websocket_server.sio.emit("message", packet.to_json()),
+            self.websocket_server._loop,
+        )
 
+    def handle_playable_list_request(self, packet: PDPlayableListReq) -> None:
+        from process_category.enum_category import E_CATE
 
+        sender = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
+        receiver = ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE)
 
+        message = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PLAYABLE_LIST_REQ)(
+            sender,
+            receiver,
+            packet.vehicle_id,
+            packet.sensor_id_list,
+            packet.start_time,
+            packet.end_time,
+        )
 
+        envelope = ProtocolWrapper.get_protocol_wrapper(message).get_protocol_packet_message()
+        self.send_message_imdg(envelope)
+
+    def handle_playable_list_response(self, packet: PDPlayableListRep) -> None:
+        """PD_PLAYABLE_LIST_REP를 socket.io로 broadcast."""
+        self.broadcast_to_clients(packet)
+
+    def handle_play_request(self, packet: PDPlayReq) -> None:
+        from process_category.enum_category import E_CATE
+
+        sender = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
+        receiver = ProtocolOwner.build(E_CATE.STREAMER, E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER)
+
+        message = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PLAY_REQ)(
+            sender,
+            receiver,
+            packet.section_id,
+            packet.vehicle_id,
+            packet.sensor_id_list,
+            packet.start_time,
+            packet.end_time,
+        )
+
+        envelope = ProtocolWrapper.get_protocol_wrapper(message).get_protocol_packet_message()
+        self.send_message_imdg(envelope)
+
+    def handle_play_response(self, packet: PDPlayRep) -> None:
+        """PD_PLAY_REP를 socket.io로 broadcast."""
+        self.broadcast_to_clients(packet)

--- a/src/app/rest/websocket_server.py
+++ b/src/app/rest/websocket_server.py
@@ -6,12 +6,8 @@ import socketio
 from fastapi import FastAPI
 import uvicorn
 
-from common.process.imdg_bus_process import IImdgBusProcess
 from common.process.queue_control_process import QueueControlProcess
-from protocol.message.external.ui.playable_list import PDPlayableListReq, PDPlayableListRep
-from protocol.message.message import IMessage
-from protocol.protocol_meta import ProtocolMeta, E_PROTOCOL_ID
-from protocol.protocol_owner import ProtocolOwner
+from protocol.protocol_meta import ProtocolMeta
 from protocol.protocol_wrapper import ProtocolWrapper
 
 
@@ -66,55 +62,13 @@ class abWebSocketServer(ABC):
 
 
 class SocketIOServer(abWebSocketServer):
+    """순수 ASGI server — 외부 socket.io 클라이언트의 진입점.
+
+    receive handler는 SocketIOProcess에 위치한다 (다른 카테고리와 일관).
+    """
+
     def __init__(self, _parents_process: QueueControlProcess, _bind_ip: str = "0.0.0.0", _bind_port: int = 9999):
         super().__init__(_parents_process, _bind_ip, _bind_port)
-
-    @staticmethod
-    def playable_list_request(
-        process: IImdgBusProcess,
-        wrapper: ProtocolWrapper,
-        packet: PDPlayableListReq,
-    ):
-        from process_category.enum_category import E_CATE
-
-
-        sender = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
-        receiver = ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE)
-
-        message = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PLAYABLE_LIST_REQ)(
-            sender,
-            receiver,
-            packet.vehicle_id,
-            packet.sensor_id_list,
-            packet.start_time,
-            packet.end_time,
-        )
-
-        envelope = ProtocolWrapper.get_protocol_wrapper(message).get_protocol_packet_message()
-        process.send_message_imdg(envelope)
-
-    @staticmethod
-    def playable_list_response(
-        process: IImdgBusProcess,
-        wrapper: ProtocolWrapper,
-        packet: IMessage,
-    ):
-        """MESSAGE_BRIDGE → REST_SERVER로 들어온 PD_PLAYABLE_LIST_REP를 socket.io로 broadcast."""
-        assert isinstance(packet, PDPlayableListRep)
-
-        # SocketIOProcess가 websocket_server를 들고 있다 (런타임 attr)
-        server: SocketIOServer | None = getattr(process, "websocket_server", None)
-        if server is None or server._loop is None:
-            print("[REST] websocket_server / asyncio loop 미초기화 — 응답 drop")
-            return
-
-        payload = packet.to_json()
-        # AsyncServer.emit은 coroutine. IMDG listener는 별도 thread이므로
-        # 메인 asyncio loop에 thread-safe하게 스케줄한다.
-        asyncio.run_coroutine_threadsafe(
-            server.sio.emit("message", payload),
-            server._loop,
-        )
 
     def on_init(self) -> None:
         @self.fastapi_app.on_event("startup")
@@ -122,7 +76,7 @@ class SocketIOServer(abWebSocketServer):
             # uvicorn이 띄운 asyncio loop을 캡처해두면 IMDG thread에서 emit 가능.
             self._loop = asyncio.get_running_loop()
 
-        # Socket.IO event
+        # Socket.IO event — 외부 클라이언트 → REST_SERVER 진입점
         @self.sio.on("message")
         async def request(sid: str, message: str):
             print("message : " + message)

--- a/src/app/streamer/process/manager/manager.py
+++ b/src/app/streamer/process/manager/manager.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from common.process.imdg_bus_process import ImdgBusProcess
+from protocol.inr_protocol_matcher.inr_pair_state import E_PROTOCOL_PAIR_STATE
+from protocol.message.imdg.play import PlayReq
+from protocol.message.message import IMessage
+
+from app.streamer.process.manager.state import (
+    E_STREAMER_MANAGER_STATE,
+    build_state_map,
+)
+
+
+class StreamerManager(ImdgBusProcess):
+    def __init__(self, app_name, process_name):
+        super().__init__(app_name, process_name)
+        self.enable_inr_matcher()
+
+    def on_init(self):
+        super().on_init()
+        self.set_state_component(
+            build_state_map(),
+            E_STREAMER_MANAGER_STATE.WAIT,
+        )
+
+    def get_current_state_id(self) -> Optional[E_STREAMER_MANAGER_STATE]:
+        if self._state_component is None:
+            return None
+        current = self._state_component.get_state_manager().get_current_state_id()
+        if current is None:
+            return None
+        assert isinstance(current, E_STREAMER_MANAGER_STATE)
+        return current
+
+    def handle_play_request(self, packet: PlayReq) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+        from protocol.protocol_owner import ProtocolOwner
+
+        if self.get_current_state_id() != E_STREAMER_MANAGER_STATE.WAIT:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.PLAY_REP,
+                ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE),
+                response=make_response_info(E_CODE.INVALID_REQUEST),
+            )
+            return
+
+        if self._state_component is not None:
+            self._state_component.change_state(E_STREAMER_MANAGER_STATE.PLAY, state_param_dto=packet)
+
+    def handle_play_response(self, packet) -> None:
+        # 매처 경로(handle_play_group_response)가 후처리 — 개별 handler는 no-op.
+        pass
+
+    def handle_play_group_response(self, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+        from protocol.protocol_owner import ProtocolOwner
+
+        bridge = ProtocolOwner.build(
+            E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE
+        )
+
+        if pair_state == E_PROTOCOL_PAIR_STATE.ERROR:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.PLAY_REP, bridge,
+                response=make_response_info(E_CODE.INVALID_REQUEST, "module error"),
+            )
+        else:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.PLAY_REP, bridge,
+                response=make_response_info(E_CODE.OK),
+            )
+
+        if self._state_component is not None:
+            self._state_component.change_state(E_STREAMER_MANAGER_STATE.WAIT)

--- a/src/app/streamer/process/manager/state/__init__.py
+++ b/src/app/streamer/process/manager/state/__init__.py
@@ -1,0 +1,14 @@
+from python_library.state import StateMap
+
+from app.streamer.process.manager.state.play import PlayState
+from app.streamer.process.manager.state.state_enum import E_STREAMER_MANAGER_STATE
+from app.streamer.process.manager.state.wait import WaitState
+
+
+def build_state_map() -> StateMap:
+    state_map = StateMap({})
+    state_map._state_map = {
+        E_STREAMER_MANAGER_STATE.WAIT: WaitState(state_map, E_STREAMER_MANAGER_STATE.WAIT),
+        E_STREAMER_MANAGER_STATE.PLAY: PlayState(state_map, E_STREAMER_MANAGER_STATE.PLAY),
+    }
+    return state_map

--- a/src/app/streamer/process/manager/state/play.py
+++ b/src/app/streamer/process/manager/state/play.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_library.state import abState
+
+from protocol.message.imdg.play import PlayReq
+
+if TYPE_CHECKING:
+    from app.streamer.process.manager.manager import StreamerManager
+
+
+class PlayState(abState):
+    owner: StreamerManager
+
+    def on_enter(self):
+        assert isinstance(self.state_param_dto, PlayReq)
+
+    def on_leave(self): pass
+
+    def on_proc_once(self):
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        assert isinstance(self.state_param_dto, PlayReq)
+
+        self.owner.broadcast_message_req_inner_queue(
+            E_PROTOCOL_ID.INR_PLAY_REQ,
+            self.state_param_dto.sensor_id_list,
+            self.state_param_dto.section_id,
+            self.state_param_dto.vehicle_id,
+            self.state_param_dto.start_time,
+            self.state_param_dto.end_time,
+            rep_protocol_id=E_PROTOCOL_ID.INR_PLAY_REP,
+        )
+
+    def on_proc_every_frame(self): pass

--- a/src/app/streamer/process/manager/state/state_enum.py
+++ b/src/app/streamer/process/manager/state/state_enum.py
@@ -1,0 +1,6 @@
+from enum import IntEnum
+
+
+class E_STREAMER_MANAGER_STATE(IntEnum):
+    WAIT = 0
+    PLAY = 1

--- a/src/app/streamer/process/manager/state/wait.py
+++ b/src/app/streamer/process/manager/state/wait.py
@@ -1,0 +1,8 @@
+from python_library.state import abState
+
+
+class WaitState(abState):
+    def on_enter(self): pass
+    def on_leave(self): pass
+    def on_proc_once(self): pass
+    def on_proc_every_frame(self): pass

--- a/src/app/streamer/process/module/module.py
+++ b/src/app/streamer/process/module/module.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from common.process.queue_control_process import QueueControlProcess
+from protocol.message.process.play import InrPlayReq
+
+from app.streamer.process.module.state import (
+    E_STREAMER_MODULE_STATE,
+    build_state_map,
+)
+
+
+class StreamerModule(QueueControlProcess):
+    def __init__(self, app_name, process_name):
+        super().__init__(app_name, process_name)
+
+    def on_init(self):
+        super().on_init()
+        self.set_state_component(
+            build_state_map(),
+            E_STREAMER_MODULE_STATE.WAIT,
+        )
+
+    def get_current_state_id(self) -> Optional[E_STREAMER_MODULE_STATE]:
+        if self._state_component is None:
+            return None
+        current = self._state_component.get_state_manager().get_current_state_id()
+        if current is None:
+            return None
+        assert isinstance(current, E_STREAMER_MODULE_STATE)
+        return current
+
+    def handle_play_request(self, packet: InrPlayReq) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        if self.get_current_state_id() != E_STREAMER_MODULE_STATE.WAIT:
+            self.send_message_rep_inner_queue(
+                E_PROTOCOL_ID.INR_PLAY_REP,
+                E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER,
+                response=make_response_info(E_CODE.INVALID_REQUEST),
+            )
+            return
+
+        if self._state_component is not None:
+            self._state_component.change_state(
+                E_STREAMER_MODULE_STATE.PLAY,
+                state_param_dto=packet,
+            )

--- a/src/app/streamer/process/module/state/__init__.py
+++ b/src/app/streamer/process/module/state/__init__.py
@@ -1,0 +1,14 @@
+from python_library.state import StateMap
+
+from app.streamer.process.module.state.play import PlayState
+from app.streamer.process.module.state.state_enum import E_STREAMER_MODULE_STATE
+from app.streamer.process.module.state.wait import WaitState
+
+
+def build_state_map() -> StateMap:
+    state_map = StateMap({})
+    state_map._state_map = {
+        E_STREAMER_MODULE_STATE.WAIT: WaitState(state_map, E_STREAMER_MODULE_STATE.WAIT),
+        E_STREAMER_MODULE_STATE.PLAY: PlayState(state_map, E_STREAMER_MODULE_STATE.PLAY),
+    }
+    return state_map

--- a/src/app/streamer/process/module/state/play.py
+++ b/src/app/streamer/process/module/state/play.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_library.state import abState
+
+from protocol.message.process.play import InrPlayReq
+
+if TYPE_CHECKING:
+    from app.streamer.process.module.module import StreamerModule
+
+
+class PlayState(abState):
+    """Pcaps/GStreamer 미이식 상태의 placeholder — 진입 즉시 OK 응답 후 WAIT 복귀."""
+    owner: StreamerModule
+
+    def on_enter(self):
+        assert isinstance(self.state_param_dto, InrPlayReq)
+
+    def on_leave(self): pass
+
+    def on_proc_once(self):
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        sensor_id = self.owner.name
+
+        self.owner.send_message_rep_inner_queue(
+            E_PROTOCOL_ID.INR_PLAY_REP,
+            E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER,
+            response=make_response_info(E_CODE.OK),
+        )
+
+        from app.streamer.process.module.state.state_enum import E_STREAMER_MODULE_STATE
+        self.owner._state_component.change_state(E_STREAMER_MODULE_STATE.WAIT)
+
+    def on_proc_every_frame(self): pass

--- a/src/app/streamer/process/module/state/state_enum.py
+++ b/src/app/streamer/process/module/state/state_enum.py
@@ -1,0 +1,6 @@
+from enum import IntEnum
+
+
+class E_STREAMER_MODULE_STATE(IntEnum):
+    WAIT = 0
+    PLAY = 1

--- a/src/app/streamer/process/module/state/wait.py
+++ b/src/app/streamer/process/module/state/wait.py
@@ -1,0 +1,8 @@
+from python_library.state import abState
+
+
+class WaitState(abState):
+    def on_enter(self): pass
+    def on_leave(self): pass
+    def on_proc_once(self): pass
+    def on_proc_every_frame(self): pass

--- a/src/process_category/enum_category.py
+++ b/src/process_category/enum_category.py
@@ -4,6 +4,8 @@ from app.downloader.process.manager.manager import DownloaderManager
 from app.downloader.process.module.module import DownloaderModule
 from app.message_bridge.process.message_bridge_process import MessageBridgeProcess
 from app.rest.process.socket_io_process import SocketIOProcess
+from app.streamer.process.manager.manager import StreamerManager
+from app.streamer.process.module.module import StreamerModule
 from sensor_category.enum_sensor import E_LIDAR, E_CAMERA
 
 
@@ -16,6 +18,7 @@ class E_CATE(IENUM):
     MESSAGE_BRIDGE="MESSAGE_BRIDGE"
     DOWNLOADER = "DOWNLOADER"
     REST_SERVER = "REST_SERVER"
+    STREAMER = "STREAMER"
 
     class E_MESSAGE_BRIDGE(IENUM):
         COMMON = "COMMON"
@@ -93,4 +96,69 @@ class E_CATE(IENUM):
         class E_COMMON(IENUM):
             REST_SERVER = "REST_SERVER"
             E_REST_SERVER = (REST_SERVER, lambda _app_name, _process_name: SocketIOProcess(_app_name,_process_name))
+
+    class E_STREAMER(IENUM):
+        COMMON = "COMMON"
+        LIDAR = "LIDAR"
+        GNSS = "GNSS"
+        CAMERA = "CAMERA"
+
+        class E_COMMON(IENUM):
+            STREAMER_MANAGER = "STREAMER_MANAGER"
+            E_STREAMER_MANAGER = (STREAMER_MANAGER, lambda _app_name, _process_name: StreamerManager(_app_name, _process_name))
+
+        class E_LIDAR(IENUM):
+            AT128_ROOF_FRONT = E_LIDAR.AT128_ROOF_FRONT
+            E_AT128_ROOF_FRONT = (AT128_ROOF_FRONT, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+            AT128_ROOF_RIGHT = E_LIDAR.AT128_ROOF_RIGHT
+            E_AT128_ROOF_RIGHT = (AT128_ROOF_RIGHT, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+            AT128_ROOF_REAR = E_LIDAR.AT128_ROOF_REAR
+            E_AT128_ROOF_REAR = (AT128_ROOF_REAR, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+            AT128_ROOF_LEFT = E_LIDAR.AT128_ROOF_LEFT
+            E_AT128_ROOF_LEFT = (AT128_ROOF_LEFT, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+
+            RSBP_BUMP_FRONT = E_LIDAR.RSBP_BUMP_FRONT
+            E_RSBP_BUMP_FRONT = (RSBP_BUMP_FRONT, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+            RSBP_BUMP_RIGHT = E_LIDAR.RSBP_BUMP_RIGHT
+            E_RSBP_BUMP_RIGHT = (RSBP_BUMP_RIGHT, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+            RSBP_BUMP_REAR = E_LIDAR.RSBP_BUMP_REAR
+            E_RSBP_BUMP_REAR = (RSBP_BUMP_REAR, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+            RSBP_BUMP_LEFT = E_LIDAR.RSBP_BUMP_LEFT
+            E_RSBP_BUMP_LEFT = (RSBP_BUMP_LEFT, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+
+        class E_GNSS(IENUM):
+            GNSS = "GNSS"
+            E_GNSS = (GNSS, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+
+        class E_CAMERA(IENUM):
+            AM20_FRONT_CENTER_RIGHT_DOWN = E_CAMERA.AM20_FRONT_CENTER_RIGHT_DOWN
+            E_AM20_FRONT_CENTER_RIGHT_DOWN = (
+                AM20_FRONT_CENTER_RIGHT_DOWN, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+            AM20_FRONT_RIGHT_REAR = E_CAMERA.AM20_FRONT_RIGHT_REAR
+            E_AM20_FRONT_RIGHT_REAR = (
+                AM20_FRONT_RIGHT_REAR, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+            AM20_REAR_CENTER_RIGHT = E_CAMERA.AM20_REAR_CENTER_RIGHT
+            E_AM20_REAR_CENTER_RIGHT = (
+                AM20_REAR_CENTER_RIGHT, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+            AM20_FRONT_LEFT_REAR = E_CAMERA.AM20_FRONT_LEFT_REAR
+            E_AM20_FRONT_LEFT_REAR = (
+                AM20_FRONT_LEFT_REAR, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+            AM20_REAR_RIGHT_EDGE = E_CAMERA.AM20_REAR_RIGHT_EDGE
+            E_AM20_REAR_RIGHT_EDGE = (
+                AM20_REAR_RIGHT_EDGE, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+
+            AM20_LEFT_REAR_EDGE = E_CAMERA.AM20_LEFT_REAR_EDGE
+            E_AM20_LEFT_REAR_EDGE = (AM20_LEFT_REAR_EDGE, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+            AM20_FRONT_CENTER_LEFT_UP = E_CAMERA.AM20_FRONT_CENTER_LEFT_UP
+            E_AM20_FRONT_CENTER_LEFT_UP = (
+                AM20_FRONT_CENTER_LEFT_UP, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+            AM20_FRONT_CENTER_RIGHT_UP = E_CAMERA.AM20_FRONT_CENTER_RIGHT_UP
+            E_AM20_FRONT_CENTER_RIGHT_UP = (
+                AM20_FRONT_CENTER_RIGHT_UP, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+            AM20_FRONT_RIGHT_FRONT = E_CAMERA.AM20_FRONT_RIGHT_FRONT
+            E_AM20_FRONT_RIGHT_FRONT = (
+                AM20_FRONT_RIGHT_FRONT, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
+            AM20_FRONT_LEFT_FRONT = E_CAMERA.AM20_FRONT_LEFT_FRONT
+            E_AM20_FRONT_LEFT_FRONT = (
+                AM20_FRONT_LEFT_FRONT, lambda _app_name, _process_name: StreamerModule(_app_name, _process_name))
 

--- a/src/process_category/process_category.py
+++ b/src/process_category/process_category.py
@@ -15,6 +15,7 @@ class ProcessCategory(AppCategory):
         self.cate_reg_queue[E_CATE.MESSAGE_BRIDGE] = lambda: self.register_message_bridge()
         self.cate_reg_queue[E_CATE.DOWNLOADER] = lambda: self.register_downloader()
         self.cate_reg_queue[E_CATE.REST_SERVER] = lambda: self.register_rest_server()
+        self.cate_reg_queue[E_CATE.STREAMER] = lambda: self.register_streamer()
 
     def register_message_bridge(self) -> None:
         message_bridge = CategoryGroup()
@@ -142,6 +143,107 @@ class ProcessCategory(AppCategory):
         downloader.push(E_CATE.E_DOWNLOADER.CAMERA, camera)
 
         self.cate_queue[E_CATE.DOWNLOADER] = downloader
+
+    def register_streamer(self) -> None:
+        """STREAMER 카테고리 등록 — DOWNLOADER 와 동일 sensor 트리."""
+        streamer = CategoryGroup()
+
+        common = CategoryGroup()
+        lidar = CategoryGroup()
+        gnss = CategoryGroup()
+        camera = CategoryGroup()
+
+        common.push(
+            E_CATE.E_STREAMER.E_COMMON.E_STREAMER_MANAGER[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_COMMON.E_STREAMER_MANAGER[E_CATE_META_ELE.LAMBDA]),
+        )
+
+        lidar.push(
+            E_CATE.E_STREAMER.E_LIDAR.E_AT128_ROOF_FRONT[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_LIDAR.E_AT128_ROOF_FRONT[E_CATE_META_ELE.LAMBDA]),
+        )
+        lidar.push(
+            E_CATE.E_STREAMER.E_LIDAR.E_AT128_ROOF_RIGHT[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_LIDAR.E_AT128_ROOF_RIGHT[E_CATE_META_ELE.LAMBDA]),
+        )
+        lidar.push(
+            E_CATE.E_STREAMER.E_LIDAR.E_AT128_ROOF_REAR[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_LIDAR.E_AT128_ROOF_REAR[E_CATE_META_ELE.LAMBDA]),
+        )
+        lidar.push(
+            E_CATE.E_STREAMER.E_LIDAR.E_AT128_ROOF_LEFT[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_LIDAR.E_AT128_ROOF_LEFT[E_CATE_META_ELE.LAMBDA]),
+        )
+
+        lidar.push(
+            E_CATE.E_STREAMER.E_LIDAR.E_RSBP_BUMP_FRONT[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_LIDAR.E_RSBP_BUMP_FRONT[E_CATE_META_ELE.LAMBDA]),
+        )
+        lidar.push(
+            E_CATE.E_STREAMER.E_LIDAR.E_RSBP_BUMP_RIGHT[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_LIDAR.E_RSBP_BUMP_RIGHT[E_CATE_META_ELE.LAMBDA]),
+        )
+        lidar.push(
+            E_CATE.E_STREAMER.E_LIDAR.E_RSBP_BUMP_REAR[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_LIDAR.E_RSBP_BUMP_REAR[E_CATE_META_ELE.LAMBDA]),
+        )
+        lidar.push(
+            E_CATE.E_STREAMER.E_LIDAR.E_RSBP_BUMP_LEFT[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_LIDAR.E_RSBP_BUMP_LEFT[E_CATE_META_ELE.LAMBDA]),
+        )
+
+        gnss.push(
+            E_CATE.E_STREAMER.E_GNSS.E_GNSS[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_GNSS.E_GNSS[E_CATE_META_ELE.LAMBDA]),
+        )
+
+        camera.push(
+            E_CATE.E_STREAMER.E_CAMERA.E_AM20_FRONT_CENTER_RIGHT_DOWN[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_CAMERA.E_AM20_FRONT_CENTER_RIGHT_DOWN[E_CATE_META_ELE.LAMBDA]),
+        )
+        camera.push(
+            E_CATE.E_STREAMER.E_CAMERA.E_AM20_FRONT_RIGHT_REAR[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_CAMERA.E_AM20_FRONT_RIGHT_REAR[E_CATE_META_ELE.LAMBDA]),
+        )
+        camera.push(
+            E_CATE.E_STREAMER.E_CAMERA.E_AM20_REAR_CENTER_RIGHT[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_CAMERA.E_AM20_REAR_CENTER_RIGHT[E_CATE_META_ELE.LAMBDA]),
+        )
+        camera.push(
+            E_CATE.E_STREAMER.E_CAMERA.E_AM20_FRONT_LEFT_REAR[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_CAMERA.E_AM20_FRONT_LEFT_REAR[E_CATE_META_ELE.LAMBDA]),
+        )
+        camera.push(
+            E_CATE.E_STREAMER.E_CAMERA.E_AM20_REAR_RIGHT_EDGE[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_CAMERA.E_AM20_REAR_RIGHT_EDGE[E_CATE_META_ELE.LAMBDA]),
+        )
+        camera.push(
+            E_CATE.E_STREAMER.E_CAMERA.E_AM20_LEFT_REAR_EDGE[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_CAMERA.E_AM20_LEFT_REAR_EDGE[E_CATE_META_ELE.LAMBDA]),
+        )
+        camera.push(
+            E_CATE.E_STREAMER.E_CAMERA.E_AM20_FRONT_CENTER_LEFT_UP[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_CAMERA.E_AM20_FRONT_CENTER_LEFT_UP[E_CATE_META_ELE.LAMBDA]),
+        )
+        camera.push(
+            E_CATE.E_STREAMER.E_CAMERA.E_AM20_FRONT_CENTER_RIGHT_UP[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_CAMERA.E_AM20_FRONT_CENTER_RIGHT_UP[E_CATE_META_ELE.LAMBDA]),
+        )
+        camera.push(
+            E_CATE.E_STREAMER.E_CAMERA.E_AM20_FRONT_RIGHT_FRONT[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_CAMERA.E_AM20_FRONT_RIGHT_FRONT[E_CATE_META_ELE.LAMBDA]),
+        )
+        camera.push(
+            E_CATE.E_STREAMER.E_CAMERA.E_AM20_FRONT_LEFT_FRONT[E_CATE_META_ELE.NAME],
+            CategoryAction(E_CATE.E_STREAMER.E_CAMERA.E_AM20_FRONT_LEFT_FRONT[E_CATE_META_ELE.LAMBDA]),
+        )
+
+        streamer.push(E_CATE.E_STREAMER.COMMON, common)
+        streamer.push(E_CATE.E_STREAMER.LIDAR, lidar)
+        streamer.push(E_CATE.E_STREAMER.GNSS, gnss)
+        streamer.push(E_CATE.E_STREAMER.CAMERA, camera)
+
+        self.cate_queue[E_CATE.STREAMER] = streamer
 
     def register_rest_server(self) -> None:
         rest_server = CategoryGroup()

--- a/src/protocol/message/external/ui/play.py
+++ b/src/protocol/message/external/ui/play.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass, field
+
+from protocol.message.external.external import pdPacket, pdResponsePacket
+
+
+@dataclass
+class PDPlayReq(pdPacket):
+    section_id: int = 0
+    vehicle_id: str = ""
+    sensor_id_list: list[str] = field(default_factory=list)
+    start_time: str = ""
+    end_time: str = ""
+
+
+@dataclass
+class PDPlayRep(pdResponsePacket):
+    pass

--- a/src/protocol/message/imdg/play.py
+++ b/src/protocol/message/imdg/play.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass, field
+
+from protocol.message.imdg.imdg import abImdgRequestMessage, abImdgResponseMessage
+
+
+@dataclass
+class PlayReq(abImdgRequestMessage):
+    section_id: int = 0
+    vehicle_id: str = ""
+    sensor_id_list: list[str] = field(default_factory=list)
+    start_time: str = ""
+    end_time: str = ""
+
+
+@dataclass
+class PlayRep(abImdgResponseMessage):
+    pass

--- a/src/protocol/message/process/play.py
+++ b/src/protocol/message/process/play.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+from protocol.message.process.process import abProcessRequestMessage, abProcessResponseMessage
+
+
+@dataclass
+class InrPlayReq(abProcessRequestMessage):
+    section_id: int = 0
+    vehicle_id: str = ""
+    start_time: str = ""
+    end_time: str = ""
+
+
+@dataclass
+class InrPlayRep(abProcessResponseMessage):
+    pass

--- a/src/protocol/protocol_handler.py
+++ b/src/protocol/protocol_handler.py
@@ -1,0 +1,101 @@
+"""모든 receive handler dispatcher를 한 곳에 모은 라우팅 테이블.
+
+- 시그니처는 모두 (process, wrapper, packet) 통일
+- 비즈니스 로직은 각 process 클래스의 handle_* instance method로 위임
+- duck typing — protocol_id가 여러 카테고리에 라우팅돼도 dispatcher는 1개
+
+group dispatcher는 시그니처가 다른 (process, pair_state, packets).
+"""
+from __future__ import annotations
+
+from protocol.inr_protocol_matcher.inr_pair_state import E_PROTOCOL_PAIR_STATE
+from protocol.message.external.ui.play import PDPlayReq, PDPlayRep
+from protocol.message.external.ui.playable_list import PDPlayableListReq, PDPlayableListRep
+from protocol.message.imdg.play import PlayReq, PlayRep
+from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
+from protocol.message.message import IMessage
+from protocol.message.process.play import InrPlayReq, InrPlayRep
+from protocol.message.process.playable_list import InrPlayableListReq, InrPlayableListRep
+from protocol.protocol_wrapper import ProtocolWrapper
+
+
+class ProtocolHandler:
+    # ---------------------------
+    # External (PD) — REST_SERVER 진입/송출
+    # ---------------------------
+    @staticmethod
+    def pd_playable_list_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PDPlayableListReq)
+        process.handle_playable_list_request(packet)
+
+    @staticmethod
+    def pd_playable_list_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PDPlayableListRep)
+        process.handle_playable_list_response(packet)
+
+    @staticmethod
+    def pd_play_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PDPlayReq)
+        process.handle_play_request(packet)
+
+    @staticmethod
+    def pd_play_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PDPlayRep)
+        process.handle_play_response(packet)
+
+    # ---------------------------
+    # IMDG — 앱 간 통신
+    # ---------------------------
+    @staticmethod
+    def playable_list_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PlayableListReq)
+        process.handle_playable_list_request(packet)
+
+    @staticmethod
+    def playable_list_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PlayableListRep)
+        process.handle_playable_list_response(packet)
+
+    @staticmethod
+    def play_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PlayReq)
+        process.handle_play_request(packet)
+
+    @staticmethod
+    def play_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PlayRep)
+        process.handle_play_response(packet)
+
+    # ---------------------------
+    # PROCESS (INR) — 앱 내 통신
+    # ---------------------------
+    @staticmethod
+    def inr_playable_list_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, InrPlayableListReq)
+        process.handle_playable_list_request(packet)
+
+    @staticmethod
+    def inr_playable_list_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, InrPlayableListRep)
+        process.handle_playable_list_response(packet)
+
+    @staticmethod
+    def inr_play_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, InrPlayReq)
+        process.handle_play_request(packet)
+
+    @staticmethod
+    def inr_play_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, InrPlayRep)
+        process.handle_play_response(packet)
+
+    # ---------------------------
+    # Group dispatchers — 시그니처 다름 (process, pair_state, packets)
+    # ---------------------------
+    @staticmethod
+    def inr_playable_list_response_group(process, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]):
+        process.handle_playable_list_group_response(pair_state, packets)
+
+    @staticmethod
+    def inr_play_response_group(process, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]):
+        process.handle_play_group_response(pair_state, packets)

--- a/src/protocol/protocol_meta.py
+++ b/src/protocol/protocol_meta.py
@@ -25,6 +25,13 @@ class E_PROTOCOL_ID(Enum):
     INR_PLAYABLE_LIST_REQ = "-100"
     INR_PLAYABLE_LIST_REP = "-101"
 
+    PD_PLAY_REQ = "PD_200"
+    PD_PLAY_REP = "PD_201"
+    PLAY_REQ = "200"
+    PLAY_REP = "201"
+    INR_PLAY_REQ = "-200"
+    INR_PLAY_REP = "-201"
+
 
 @dataclass(frozen=True)
 class ProtocolEntry:
@@ -69,15 +76,17 @@ class ProtocolMeta:
     @classmethod
     def _register_protocols(cls) -> None:
         from process_category.enum_category import E_CATE
-        from app.rest.websocket_server import SocketIOServer
-        from app.downloader.process.manager.manager import DownloaderManager
-        from app.downloader.process.module.module import DownloaderModule
-        from app.message_bridge.process.message_bridge_process import MessageBridgeProcess
+        from protocol.message.external.ui.play import PDPlayReq, PDPlayRep
         from protocol.message.external.ui.playable_list import PDPlayableListReq, PDPlayableListRep
+        from protocol.message.imdg.play import PlayReq, PlayRep
         from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
+        from protocol.message.process.play import InrPlayReq, InrPlayRep
         from protocol.message.process.playable_list import InrPlayableListReq, InrPlayableListRep
+        from protocol.protocol_handler import ProtocolHandler
 
-        # PD (외부 통신, raw dataclass)
+        # ===== PlayableList 3계층 =====
+
+        # PD_PLAYABLE_LIST_REQ → REST_SERVER
         cls._register(
             E_PROTOCOL_ID.PD_PLAYABLE_LIST_REQ,
             ProtocolEntry(
@@ -92,14 +101,12 @@ class ProtocolMeta:
                 ),
                 decoder=PDPlayableListReq.from_json,
                 receive_handlers={
-                    E_CATE.REST_SERVER: lambda process, wrapper, packet: SocketIOServer.playable_list_request(
-                        process, wrapper, packet
-                    ),
+                    E_CATE.REST_SERVER: ProtocolHandler.pd_playable_list_request,
                 },
             ),
         )
 
-        # PD (외부 통신, RESPONSE) — REST_SERVER가 IMDG로 받아 socket.io broadcast
+        # PD_PLAYABLE_LIST_REP → REST_SERVER (socket.io broadcast)
         cls._register(
             E_PROTOCOL_ID.PD_PLAYABLE_LIST_REP,
             ProtocolEntry(
@@ -115,14 +122,12 @@ class ProtocolMeta:
                 ),
                 decoder=PDPlayableListRep.from_json,
                 receive_handlers={
-                    E_CATE.REST_SERVER: lambda process, wrapper, packet: SocketIOServer.playable_list_response(
-                        process, wrapper, packet
-                    ),
+                    E_CATE.REST_SERVER: ProtocolHandler.pd_playable_list_response,
                 },
             ),
         )
 
-        # IMDG (앱 간 통신)
+        # PLAYABLE_LIST_REQ → MESSAGE_BRIDGE / DOWNLOADER
         cls._register(
             E_PROTOCOL_ID.PLAYABLE_LIST_REQ,
             ProtocolEntry(
@@ -137,17 +142,13 @@ class ProtocolMeta:
                 ),
                 decoder=PlayableListReq.from_json,
                 receive_handlers={
-                    E_CATE.MESSAGE_BRIDGE: lambda process, wrapper, packet: (
-                        MessageBridgeProcess.playable_list_request(process, wrapper, packet)
-                    ),
-                    E_CATE.DOWNLOADER: lambda process, wrapper, packet: (
-                        DownloaderManager.playable_list_request(process, wrapper, packet)
-                    ),
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.playable_list_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.playable_list_request,
                 },
             ),
         )
 
-        # IMDG (앱 간 통신, RESPONSE)
+        # PLAYABLE_LIST_REP → MESSAGE_BRIDGE
         cls._register(
             E_PROTOCOL_ID.PLAYABLE_LIST_REP,
             ProtocolEntry(
@@ -161,14 +162,12 @@ class ProtocolMeta:
                 ),
                 decoder=PlayableListRep.from_json,
                 receive_handlers={
-                    E_CATE.MESSAGE_BRIDGE: lambda process, wrapper, packet: (
-                        MessageBridgeProcess.playable_list_response(process, wrapper, packet)
-                    ),
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.playable_list_response,
                 },
             ),
         )
 
-        # PROCESS (앱 내 통신)
+        # INR_PLAYABLE_LIST_REQ → DOWNLOADER (Module)
         cls._register(
             E_PROTOCOL_ID.INR_PLAYABLE_LIST_REQ,
             ProtocolEntry(
@@ -182,14 +181,12 @@ class ProtocolMeta:
                 ),
                 decoder=InrPlayableListReq.from_json,
                 receive_handlers={
-                    E_CATE.DOWNLOADER: lambda process, wrapper, packet: (
-                        DownloaderModule.playable_list_request(process, wrapper, packet)
-                    )
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_playable_list_request,
                 },
             ),
         )
 
-        # PROCESS (앱 내 통신, RESPONSE)
+        # INR_PLAYABLE_LIST_REP → DOWNLOADER (Manager) + group
         cls._register(
             E_PROTOCOL_ID.INR_PLAYABLE_LIST_REP,
             ProtocolEntry(
@@ -203,14 +200,134 @@ class ProtocolMeta:
                 ),
                 decoder=InrPlayableListRep.from_json,
                 receive_handlers={
-                    E_CATE.DOWNLOADER: lambda process, wrapper, packet: (
-                        DownloaderManager.playable_list_response(process, wrapper, packet)
-                    )
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_playable_list_response,
                 },
                 inr_group_receive_handlers={
-                    E_CATE.DOWNLOADER: lambda process, pair_state, packets: (
-                        DownloaderManager.playable_list_group_response(process, pair_state, packets)
-                    )
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_playable_list_response_group,
+                },
+            ),
+        )
+
+        # ===== Play 3계층 =====
+
+        # PD_PLAY_REQ → REST_SERVER
+        cls._register(
+            E_PROTOCOL_ID.PD_PLAY_REQ,
+            ProtocolEntry(
+                factory=lambda sender, receiver, section_id, vehicle_id, sensor_id_list, start_time, end_time: PDPlayReq(
+                    protocol_id=E_PROTOCOL_ID.PD_PLAY_REQ.value,
+                    sender=sender,
+                    receiver=receiver,
+                    section_id=section_id,
+                    vehicle_id=vehicle_id,
+                    sensor_id_list=sensor_id_list if sensor_id_list is not None else [],
+                    start_time=start_time,
+                    end_time=end_time,
+                ),
+                decoder=PDPlayReq.from_json,
+                receive_handlers={
+                    E_CATE.REST_SERVER: ProtocolHandler.pd_play_request,
+                },
+            ),
+        )
+
+        # PD_PLAY_REP → REST_SERVER (socket.io broadcast)
+        cls._register(
+            E_PROTOCOL_ID.PD_PLAY_REP,
+            ProtocolEntry(
+                factory=lambda sender, receiver, code, code_nm, reason: PDPlayRep(
+                    protocol_id=E_PROTOCOL_ID.PD_PLAY_REP.value,
+                    sender=sender,
+                    receiver=receiver,
+                    code=code,
+                    code_nm=code_nm,
+                    reason=reason,
+                ),
+                decoder=PDPlayRep.from_json,
+                receive_handlers={
+                    E_CATE.REST_SERVER: ProtocolHandler.pd_play_response,
+                },
+            ),
+        )
+
+        # PLAY_REQ → BRIDGE / STREAMER / DOWNLOADER (replayer broadcast 패턴)
+        cls._register(
+            E_PROTOCOL_ID.PLAY_REQ,
+            ProtocolEntry(
+                factory=lambda sender, receiver, section_id, vehicle_id, sensor_id_list, start_time, end_time: PlayReq(
+                    protocol_id=E_PROTOCOL_ID.PLAY_REQ.value,
+                    sender=sender,
+                    receiver=receiver,
+                    section_id=section_id,
+                    vehicle_id=vehicle_id,
+                    sensor_id_list=sensor_id_list if sensor_id_list is not None else [],
+                    start_time=start_time,
+                    end_time=end_time,
+                ),
+                decoder=PlayReq.from_json,
+                receive_handlers={
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.play_request,
+                    E_CATE.STREAMER: ProtocolHandler.play_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.play_request,
+                },
+            ),
+        )
+
+        # PLAY_REP → MESSAGE_BRIDGE
+        cls._register(
+            E_PROTOCOL_ID.PLAY_REP,
+            ProtocolEntry(
+                factory=lambda sender, receiver, response=None: PlayRep(
+                    protocol_id=E_PROTOCOL_ID.PLAY_REP.value,
+                    sender=sender,
+                    receiver=receiver,
+                    response=response,
+                ),
+                decoder=PlayRep.from_json,
+                receive_handlers={
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.play_response,
+                },
+            ),
+        )
+
+        # INR_PLAY_REQ → STREAMER (Module) / DOWNLOADER (Module)
+        cls._register(
+            E_PROTOCOL_ID.INR_PLAY_REQ,
+            ProtocolEntry(
+                factory=lambda sender, receiver, section_id, vehicle_id, start_time, end_time: InrPlayReq(
+                    protocol_id=E_PROTOCOL_ID.INR_PLAY_REQ.value,
+                    sender=sender,
+                    receiver=receiver,
+                    section_id=section_id,
+                    vehicle_id=vehicle_id,
+                    start_time=start_time,
+                    end_time=end_time,
+                ),
+                decoder=InrPlayReq.from_json,
+                receive_handlers={
+                    E_CATE.STREAMER: ProtocolHandler.inr_play_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_play_request,
+                },
+            ),
+        )
+
+        # INR_PLAY_REP → STREAMER (Manager) / DOWNLOADER (Manager) + group
+        cls._register(
+            E_PROTOCOL_ID.INR_PLAY_REP,
+            ProtocolEntry(
+                factory=lambda sender, receiver, response=None: InrPlayRep(
+                    protocol_id=E_PROTOCOL_ID.INR_PLAY_REP.value,
+                    sender=sender,
+                    receiver=receiver,
+                    response=response,
+                ),
+                decoder=InrPlayRep.from_json,
+                receive_handlers={
+                    E_CATE.STREAMER: ProtocolHandler.inr_play_response,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_play_response,
+                },
+                inr_group_receive_handlers={
+                    E_CATE.STREAMER: ProtocolHandler.inr_play_response_group,
                 },
             ),
         )

--- a/src/streamer_app.py
+++ b/src/streamer_app.py
@@ -1,0 +1,33 @@
+import time
+
+from app.app_object import MultiProcessManagerAppFromCate
+from process_category.enum_category import E_CATE
+from process_category.process_category import ProcessCategory
+from config.project_config import ProjectConfig
+
+
+class Streamer(MultiProcessManagerAppFromCate):
+
+    def __init__(self, *_cate):
+        super().__init__(E_CATE.STREAMER, *_cate)
+
+    def init(self):
+        self.get_multi_process_manager().start()
+
+    def on_run(self):
+        time.sleep(0.005)
+        pass
+
+
+def main():
+    ProjectConfig.set_config(ProjectConfig.DEFAULT_CONFIG_PATH)
+
+    ProcessCategory.instance().register_streamer()
+
+    app = Streamer(E_CATE.STREAMER)
+    app.init()
+    app.run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- **Play 패킷 3계층**: PD_PLAY_REQ/REP, PLAY_REQ/REP, INR_PLAY_REQ/REP 6종 메시지 + ProtocolEntry 등록
- **Streamer 도메인 신설**: E_CATE.STREAMER, ProcessCategory.register_streamer, StreamerManager/Module + WAIT/PLAY state machine, streamer_app.py 진입점
- **PLAY handler 본체**: STREAMER+DOWNLOADER+BRIDGE 3 receivers broadcast (replayer 패턴) — Streamer 흐름은 진짜 구현, DOWNLOADER 쪽은 Download 본체 미구현이라 NotImplementedError 유지, StreamerModule는 Pcaps/GStreamer 미이식이라 즉시 OK 응답 placeholder
- **ProtocolHandler 중앙화 리팩터링**: 모든 receive handler dispatcher를 `protocol/protocol_handler.py` 한 클래스로 집중 (C# PacketManager/Handler 패턴 미러). 각 process 클래스는 `handle_*` instance method만 보유. ProtocolMeta는 ProtocolHandler.* 를 직접 참조 (lambda 래퍼 제거)
- **SocketIOServer→SocketIOProcess 이동**: REST receive handler를 다른 카테고리와 일관되게 process 클래스로 이동, broadcast_to_clients helper 추출

## Related Issues
- close #58