### PR TITLE
[test] #60 Play 패킷 end-to-end 테스트 추가 (PlayableList → Play 연속 시나리오)

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -2,19 +2,22 @@
 set -e
 cd "$(dirname "$0")/.."
 
-# 백그라운드로 3개 서버 실행
+# 백그라운드로 4개 서버 실행
 uv run python src/rest_server_app.py &
-PID_REST=$!
+PID_REST_SERVER=$!
 uv run python src/message_bridge_app.py &
-PID_MB=$!
+PID_MESSAGE_BRIDGE=$!
 uv run python src/downloader_app.py &
-PID_DL=$!
+PID_DOWNLOADER=$!
+uv run python src/streamer_app.py &
+PID_STREAMER=$!
 
 # 종료 시 정리
-trap "kill $PID_REST $PID_MB $PID_DL 2>/dev/null || true" EXIT
+trap "kill $PID_REST_SERVER $PID_MESSAGE_BRIDGE $PID_DOWNLOADER $PID_STREAMER 2>/dev/null || true" EXIT
 
 # 서버 startup 대기
 sleep 2
 
 # 테스트 실행
-uv run pytest tests/test_client/test_client.py -s
+uv run pytest tests/test_client/test_playable_list.py -s
+uv run pytest tests/test_client/test_play.py -s

--- a/src/app/rest/websocket_server.py
+++ b/src/app/rest/websocket_server.py
@@ -79,8 +79,6 @@ class SocketIOServer(abWebSocketServer):
         # Socket.IO event — 외부 클라이언트 → REST_SERVER 진입점
         @self.sio.on("message")
         async def request(sid: str, message: str):
-            print("message : " + message)
-
             parsed_dict = json.loads(message)
 
             protocol_id = parsed_dict["protocol_id"]

--- a/tests/test_client/test_play.py
+++ b/tests/test_client/test_play.py
@@ -1,0 +1,93 @@
+import json
+import threading
+
+import socketio
+
+
+def test_playable_list_then_play():
+    """PlayableList → 응답에서 section 골라 Play 연속 시나리오.
+
+    full flow:
+        1) client → REST_SERVER → MESSAGE_BRIDGE → DOWNLOADER (lookup)
+                 ← REST_SERVER ← MESSAGE_BRIDGE ← DOWNLOADER (PD_PLAYABLE_LIST_REP)
+        2) client → REST_SERVER → STREAMER Manager (PLAY state) → STREAMER modules (placeholder OK)
+                 ← REST_SERVER ← MESSAGE_BRIDGE ← STREAMER Manager (PD_PLAY_REP via group_response)
+
+    참고:
+      - PLAY_REQ는 BRIDGE+STREAMER+DOWNLOADER 3 receivers broadcast.
+      - DOWNLOADER 쪽 handle_play_request은 NotImplementedError지만
+        listener catch 후 STREAMER 흐름은 독립 진행.
+      - StreamerModule.PlayState는 placeholder(즉시 OK 응답 후 WAIT 복귀).
+    """
+    sio = socketio.Client()
+    state: dict = {"playable_list": None, "play": None}
+    list_event = threading.Event()
+    play_event = threading.Event()
+
+    @sio.event
+    def connect():
+        print("[client] connected")
+
+    @sio.event
+    def disconnect():
+        print("[client] disconnected")
+
+    def on_message(data):
+        print(f"[client] recv: {data}")
+        parsed = json.loads(data) if isinstance(data, str) else data
+        pid = parsed.get("protocol_id")
+        if pid == "PD_101":
+            state["playable_list"] = parsed
+            list_event.set()
+        elif pid == "PD_201":
+            state["play"] = parsed
+            play_event.set()
+
+    sio.on("message", on_message)
+    sio.connect("http://localhost:9999", wait_timeout=10)
+
+    # 1) PlayableList 요청
+    list_request = {
+        "protocol_id": "PD_100",
+        "message_direction": 0,
+        "sender": "UI",
+        "receiver": "REST_SERVER",
+        "vehicle_id": "vehicle-001",
+        "sensor_id_list": ["AT128_ROOF_FRONT", "GNSS"],
+        "start_time": "20240101120000",
+        "end_time": "20240101120100",
+    }
+    sio.emit("message", json.dumps(list_request))
+    print(f"[client] sent: {list_request}")
+
+    got_list = list_event.wait(timeout=15)
+    assert got_list, "PD_PLAYABLE_LIST_REP 응답을 시간 내 받지 못함"
+    assert state["playable_list"]["protocol_id"] == "PD_101"
+
+    sections = state["playable_list"].get("section_list") or []
+    sensors = state["playable_list"].get("sensor_id_list") or []
+    assert sections, "재생 가능한 section이 없음 — Play 단계 진행 불가"
+    chosen = sections[0]
+    print(f"[client] chosen section: {chosen}")
+
+    # 2) 응답에서 받은 첫 section을 토대로 Play 요청
+    play_request = {
+        "protocol_id": "PD_200",
+        "message_direction": 0,
+        "sender": "UI",
+        "receiver": "REST_SERVER",
+        "section_id": chosen["sectionId"],
+        "vehicle_id": "vehicle-001",
+        "sensor_id_list": sensors,
+        "start_time": chosen["startTime"],
+        "end_time": chosen["endTime"],
+    }
+    sio.emit("message", json.dumps(play_request))
+    print(f"[client] sent: {play_request}")
+
+    got_play = play_event.wait(timeout=15)
+    sio.disconnect()
+
+    assert got_play, "PD_PLAY_REP 응답을 시간 내 받지 못함"
+    assert state["play"]["protocol_id"] == "PD_201"
+    print(f"[client] play code={state['play'].get('code')} reason={state['play'].get('reason')}")

--- a/tests/test_client/test_playable_list.py
+++ b/tests/test_client/test_playable_list.py
@@ -4,7 +4,7 @@ import threading
 import socketio
 
 
-def test_client():
+def test_playable_list():
     """REST_SERVER로 PD_PLAYABLE_LIST_REQ를 보내고 PD_PLAYABLE_LIST_REP를 수신.
 
     full flow:


### PR DESCRIPTION
## Summary
- **`test_play.py` 신규**: PlayableList(PD_100) 응답에서 받은 첫 section을 토대로 PD_PLAY_REQ(PD_200) 송신 → PD_PLAY_REP(PD_201) 검증하는 e2e 시나리오
- **`test_client.py → test_playable_list.py` rename**: 새 `test_play.py`와 짝 맞춰 의도가 드러나는 파일명 + 함수명(`test_client` → `test_playable_list`)
- **`scripts/dev.sh` 정비**: 본 PR(#59)에서 추가된 `streamer_app.py` 실행 추가, PID 변수명 명확화, `test_play` 실행 추가
- **`websocket_server.py` 디버그 print 제거**: `sio.on("message")` 진입 시 메시지 raw print하던 1줄 정리

## Related Issues
- close #60