### PR TITLE
[feat] #62 Pause 패킷 3계층(PD/IMDG/INR) 추가

### DIFF
--- a/src/app/downloader/process/manager/manager.py
+++ b/src/app/downloader/process/manager/manager.py
@@ -122,3 +122,9 @@ class DownloaderManager(ImdgBusProcess):
 
     def handle_play_response(self, packet: InrPlayRep) -> None:
         raise NotImplementedError
+
+    def handle_pause_request(self, packet) -> None:
+        raise NotImplementedError
+
+    def handle_pause_response(self, packet) -> None:
+        raise NotImplementedError

--- a/src/app/downloader/process/module/module.py
+++ b/src/app/downloader/process/module/module.py
@@ -78,3 +78,6 @@ class DownloaderModule(QueueControlProcess):
 
     def handle_play_request(self, packet: InrPlayReq) -> None:
         raise NotImplementedError
+
+    def handle_pause_request(self, packet) -> None:
+        raise NotImplementedError

--- a/src/app/message_bridge/process/message_bridge_process.py
+++ b/src/app/message_bridge/process/message_bridge_process.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from common.process.imdg_bus_process import ImdgBusProcess
+from protocol.message.imdg.pause import PauseReq, PauseRep
 from protocol.message.imdg.play import PlayReq, PlayRep
 from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
 from protocol.message.message import ResponseInfo
@@ -81,6 +82,30 @@ class MessageBridgeProcess(ImdgBusProcess):
         response: ResponseInfo = packet.response or ResponseInfo()
         receiver = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
         factory = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PD_PLAY_REP)
+        sender = ProtocolOwner.build(self.get_app_name(), self.name)
+
+        fwd_packet = factory(
+            sender,
+            receiver,
+            response.code,
+            response.code_nm,
+            response.reason,
+        )
+        envelope = ProtocolWrapper.get_protocol_wrapper(fwd_packet).get_protocol_packet_message()
+        self.send_message_imdg(envelope)
+
+    def handle_pause_request(self, packet: PauseReq) -> None:
+        # PAUSE_REQ는 STREAMER도 broadcast로 받으므로 BRIDGE는 forward 불필요 — no-op.
+        pass
+
+    def handle_pause_response(self, packet: PauseRep) -> None:
+        """STREAMER → MESSAGE_BRIDGE로 들어온 PAUSE_REP를 PD_PAUSE_REP로 변환해 REST_SERVER로 IMDG 송신."""
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_owner import ProtocolOwner
+
+        response: ResponseInfo = packet.response or ResponseInfo()
+        receiver = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
+        factory = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PD_PAUSE_REP)
         sender = ProtocolOwner.build(self.get_app_name(), self.name)
 
         fwd_packet = factory(

--- a/src/app/rest/process/socket_io_process.py
+++ b/src/app/rest/process/socket_io_process.py
@@ -5,6 +5,7 @@ import asyncio
 from app.rest.websocket_server import SocketIOServer
 from common.process.imdg_bus_process import ImdgBusProcess
 from config.project_config import ProjectConfig
+from protocol.message.external.ui.pause import PDPauseReq, PDPauseRep
 from protocol.message.external.ui.play import PDPlayReq, PDPlayRep
 from protocol.message.external.ui.playable_list import PDPlayableListReq, PDPlayableListRep
 from protocol.message.message import IMessage
@@ -81,4 +82,22 @@ class SocketIOProcess(ImdgBusProcess):
 
     def handle_play_response(self, packet: PDPlayRep) -> None:
         """PD_PLAY_REP를 socket.io로 broadcast."""
+        self.broadcast_to_clients(packet)
+
+    def handle_pause_request(self, packet: PDPauseReq) -> None:
+        from process_category.enum_category import E_CATE
+
+        sender = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
+        receiver = ProtocolOwner.build(E_CATE.STREAMER, E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER)
+
+        message = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PAUSE_REQ)(
+            sender,
+            receiver,
+        )
+
+        envelope = ProtocolWrapper.get_protocol_wrapper(message).get_protocol_packet_message()
+        self.send_message_imdg(envelope)
+
+    def handle_pause_response(self, packet: PDPauseRep) -> None:
+        """PD_PAUSE_REP를 socket.io로 broadcast."""
         self.broadcast_to_clients(packet)

--- a/src/app/streamer/process/manager/manager.py
+++ b/src/app/streamer/process/manager/manager.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from common.process.imdg_bus_process import ImdgBusProcess
 from protocol.inr_protocol_matcher.inr_pair_state import E_PROTOCOL_PAIR_STATE
+from protocol.message.imdg.pause import PauseReq
 from protocol.message.imdg.play import PlayReq
 from protocol.message.message import IMessage
 
@@ -73,6 +74,51 @@ class StreamerManager(ImdgBusProcess):
         else:
             self.send_message_rep_imdg(
                 E_PROTOCOL_ID.PLAY_REP, bridge,
+                response=make_response_info(E_CODE.OK),
+            )
+
+        if self._state_component is not None:
+            self._state_component.change_state(E_STREAMER_MANAGER_STATE.WAIT)
+
+    def handle_pause_request(self, packet: PauseReq) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+        from protocol.protocol_owner import ProtocolOwner
+
+        if self.get_current_state_id() != E_STREAMER_MANAGER_STATE.PLAY:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.PAUSE_REP,
+                ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE),
+                response=make_response_info(E_CODE.INVALID_REQUEST),
+            )
+            return
+
+        if self._state_component is not None:
+            self._state_component.change_state(E_STREAMER_MANAGER_STATE.PAUSE, state_param_dto=packet)
+
+    def handle_pause_response(self, packet) -> None:
+        # 매처 경로(handle_pause_group_response)가 후처리 — 개별 handler는 no-op.
+        pass
+
+    def handle_pause_group_response(self, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+        from protocol.protocol_owner import ProtocolOwner
+
+        bridge = ProtocolOwner.build(
+            E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE
+        )
+
+        if pair_state == E_PROTOCOL_PAIR_STATE.ERROR:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.PAUSE_REP, bridge,
+                response=make_response_info(E_CODE.INVALID_REQUEST, "module error"),
+            )
+        else:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.PAUSE_REP, bridge,
                 response=make_response_info(E_CODE.OK),
             )
 

--- a/src/app/streamer/process/manager/state/__init__.py
+++ b/src/app/streamer/process/manager/state/__init__.py
@@ -1,5 +1,6 @@
 from python_library.state import StateMap
 
+from app.streamer.process.manager.state.pause import PauseState
 from app.streamer.process.manager.state.play import PlayState
 from app.streamer.process.manager.state.state_enum import E_STREAMER_MANAGER_STATE
 from app.streamer.process.manager.state.wait import WaitState
@@ -10,5 +11,6 @@ def build_state_map() -> StateMap:
     state_map._state_map = {
         E_STREAMER_MANAGER_STATE.WAIT: WaitState(state_map, E_STREAMER_MANAGER_STATE.WAIT),
         E_STREAMER_MANAGER_STATE.PLAY: PlayState(state_map, E_STREAMER_MANAGER_STATE.PLAY),
+        E_STREAMER_MANAGER_STATE.PAUSE: PauseState(state_map, E_STREAMER_MANAGER_STATE.PAUSE),
     }
     return state_map

--- a/src/app/streamer/process/manager/state/pause.py
+++ b/src/app/streamer/process/manager/state/pause.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_library.state import abState
+
+from protocol.message.imdg.pause import PauseReq
+
+if TYPE_CHECKING:
+    from app.streamer.process.manager.manager import StreamerManager
+
+
+class PauseState(abState):
+    owner: StreamerManager
+
+    def on_enter(self):
+        assert isinstance(self.state_param_dto, PauseReq)
+
+    def on_leave(self): pass
+
+    def on_proc_once(self):
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        # 모든 sensor module에 INR_PAUSE_REQ broadcast.
+        # receiver_process_names는 Streamer Manager가 보유한 module list — 현 placeholder는 빈 리스트.
+        # 실제 sensor list 추적은 PLAY state 진입 시 owner에 저장 필요 (후속 작업).
+        receivers: list[str] = []
+
+        self.owner.broadcast_message_req_inner_queue(
+            E_PROTOCOL_ID.INR_PAUSE_REQ,
+            receivers,
+            rep_protocol_id=E_PROTOCOL_ID.INR_PAUSE_REP,
+        )
+
+    def on_proc_every_frame(self): pass

--- a/src/app/streamer/process/manager/state/state_enum.py
+++ b/src/app/streamer/process/manager/state/state_enum.py
@@ -4,3 +4,4 @@ from enum import IntEnum
 class E_STREAMER_MANAGER_STATE(IntEnum):
     WAIT = 0
     PLAY = 1
+    PAUSE = 2

--- a/src/app/streamer/process/module/module.py
+++ b/src/app/streamer/process/module/module.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 from common.process.queue_control_process import QueueControlProcess
+from protocol.message.process.pause import InrPauseReq
 from protocol.message.process.play import InrPlayReq
 
 from app.streamer.process.module.state import (
@@ -47,5 +48,17 @@ class StreamerModule(QueueControlProcess):
         if self._state_component is not None:
             self._state_component.change_state(
                 E_STREAMER_MODULE_STATE.PLAY,
+                state_param_dto=packet,
+            )
+
+    def handle_pause_request(self, packet: InrPauseReq) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        # placeholder — 실제 GStreamer pause 흐름 미이식. 어떤 state든 일단 PAUSE 진입 후 즉시 OK.
+        if self._state_component is not None:
+            self._state_component.change_state(
+                E_STREAMER_MODULE_STATE.PAUSE,
                 state_param_dto=packet,
             )

--- a/src/app/streamer/process/module/state/__init__.py
+++ b/src/app/streamer/process/module/state/__init__.py
@@ -1,5 +1,6 @@
 from python_library.state import StateMap
 
+from app.streamer.process.module.state.pause import PauseState
 from app.streamer.process.module.state.play import PlayState
 from app.streamer.process.module.state.state_enum import E_STREAMER_MODULE_STATE
 from app.streamer.process.module.state.wait import WaitState
@@ -10,5 +11,6 @@ def build_state_map() -> StateMap:
     state_map._state_map = {
         E_STREAMER_MODULE_STATE.WAIT: WaitState(state_map, E_STREAMER_MODULE_STATE.WAIT),
         E_STREAMER_MODULE_STATE.PLAY: PlayState(state_map, E_STREAMER_MODULE_STATE.PLAY),
+        E_STREAMER_MODULE_STATE.PAUSE: PauseState(state_map, E_STREAMER_MODULE_STATE.PAUSE),
     }
     return state_map

--- a/src/app/streamer/process/module/state/pause.py
+++ b/src/app/streamer/process/module/state/pause.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_library.state import abState
+
+from protocol.message.process.pause import InrPauseReq
+
+if TYPE_CHECKING:
+    from app.streamer.process.module.module import StreamerModule
+
+
+class PauseState(abState):
+    """Pcaps/GStreamer 미이식 상태의 placeholder — 진입 즉시 OK 응답 후 WAIT 복귀."""
+    owner: StreamerModule
+
+    def on_enter(self):
+        assert isinstance(self.state_param_dto, InrPauseReq)
+
+    def on_leave(self): pass
+
+    def on_proc_once(self):
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        self.owner.send_message_rep_inner_queue(
+            E_PROTOCOL_ID.INR_PAUSE_REP,
+            E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER,
+            response=make_response_info(E_CODE.OK),
+        )
+
+        from app.streamer.process.module.state.state_enum import E_STREAMER_MODULE_STATE
+        self.owner._state_component.change_state(E_STREAMER_MODULE_STATE.WAIT)
+
+    def on_proc_every_frame(self): pass

--- a/src/app/streamer/process/module/state/state_enum.py
+++ b/src/app/streamer/process/module/state/state_enum.py
@@ -4,3 +4,4 @@ from enum import IntEnum
 class E_STREAMER_MODULE_STATE(IntEnum):
     WAIT = 0
     PLAY = 1
+    PAUSE = 2

--- a/src/protocol/message/external/ui/pause.py
+++ b/src/protocol/message/external/ui/pause.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from protocol.message.external.external import pdPacket, pdResponsePacket
+
+
+@dataclass
+class PDPauseReq(pdPacket):
+    pass
+
+
+@dataclass
+class PDPauseRep(pdResponsePacket):
+    pass

--- a/src/protocol/message/imdg/pause.py
+++ b/src/protocol/message/imdg/pause.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from protocol.message.imdg.imdg import abImdgRequestMessage, abImdgResponseMessage
+
+
+@dataclass
+class PauseReq(abImdgRequestMessage):
+    pass
+
+
+@dataclass
+class PauseRep(abImdgResponseMessage):
+    pass

--- a/src/protocol/message/process/pause.py
+++ b/src/protocol/message/process/pause.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from protocol.message.process.process import abProcessRequestMessage, abProcessResponseMessage
+
+
+@dataclass
+class InrPauseReq(abProcessRequestMessage):
+    pass
+
+
+@dataclass
+class InrPauseRep(abProcessResponseMessage):
+    pass

--- a/src/protocol/protocol_handler.py
+++ b/src/protocol/protocol_handler.py
@@ -9,11 +9,14 @@ group dispatcher는 시그니처가 다른 (process, pair_state, packets).
 from __future__ import annotations
 
 from protocol.inr_protocol_matcher.inr_pair_state import E_PROTOCOL_PAIR_STATE
+from protocol.message.external.ui.pause import PDPauseReq, PDPauseRep
 from protocol.message.external.ui.play import PDPlayReq, PDPlayRep
 from protocol.message.external.ui.playable_list import PDPlayableListReq, PDPlayableListRep
+from protocol.message.imdg.pause import PauseReq, PauseRep
 from protocol.message.imdg.play import PlayReq, PlayRep
 from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
 from protocol.message.message import IMessage
+from protocol.message.process.pause import InrPauseReq, InrPauseRep
 from protocol.message.process.play import InrPlayReq, InrPlayRep
 from protocol.message.process.playable_list import InrPlayableListReq, InrPlayableListRep
 from protocol.protocol_wrapper import ProtocolWrapper
@@ -43,6 +46,16 @@ class ProtocolHandler:
         assert isinstance(packet, PDPlayRep)
         process.handle_play_response(packet)
 
+    @staticmethod
+    def pd_pause_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PDPauseReq)
+        process.handle_pause_request(packet)
+
+    @staticmethod
+    def pd_pause_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PDPauseRep)
+        process.handle_pause_response(packet)
+
     # ---------------------------
     # IMDG — 앱 간 통신
     # ---------------------------
@@ -65,6 +78,16 @@ class ProtocolHandler:
     def play_response(process, wrapper: ProtocolWrapper, packet: IMessage):
         assert isinstance(packet, PlayRep)
         process.handle_play_response(packet)
+
+    @staticmethod
+    def pause_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PauseReq)
+        process.handle_pause_request(packet)
+
+    @staticmethod
+    def pause_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PauseRep)
+        process.handle_pause_response(packet)
 
     # ---------------------------
     # PROCESS (INR) — 앱 내 통신
@@ -89,6 +112,16 @@ class ProtocolHandler:
         assert isinstance(packet, InrPlayRep)
         process.handle_play_response(packet)
 
+    @staticmethod
+    def inr_pause_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, InrPauseReq)
+        process.handle_pause_request(packet)
+
+    @staticmethod
+    def inr_pause_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, InrPauseRep)
+        process.handle_pause_response(packet)
+
     # ---------------------------
     # Group dispatchers — 시그니처 다름 (process, pair_state, packets)
     # ---------------------------
@@ -99,3 +132,7 @@ class ProtocolHandler:
     @staticmethod
     def inr_play_response_group(process, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]):
         process.handle_play_group_response(pair_state, packets)
+
+    @staticmethod
+    def inr_pause_response_group(process, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]):
+        process.handle_pause_group_response(pair_state, packets)

--- a/src/protocol/protocol_meta.py
+++ b/src/protocol/protocol_meta.py
@@ -32,6 +32,13 @@ class E_PROTOCOL_ID(Enum):
     INR_PLAY_REQ = "-200"
     INR_PLAY_REP = "-201"
 
+    PD_PAUSE_REQ = "PD_400"
+    PD_PAUSE_REP = "PD_401"
+    PAUSE_REQ = "400"
+    PAUSE_REP = "401"
+    INR_PAUSE_REQ = "-400"
+    INR_PAUSE_REP = "-401"
+
 
 @dataclass(frozen=True)
 class ProtocolEntry:
@@ -76,10 +83,13 @@ class ProtocolMeta:
     @classmethod
     def _register_protocols(cls) -> None:
         from process_category.enum_category import E_CATE
+        from protocol.message.external.ui.pause import PDPauseReq, PDPauseRep
         from protocol.message.external.ui.play import PDPlayReq, PDPlayRep
         from protocol.message.external.ui.playable_list import PDPlayableListReq, PDPlayableListRep
+        from protocol.message.imdg.pause import PauseReq, PauseRep
         from protocol.message.imdg.play import PlayReq, PlayRep
         from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
+        from protocol.message.process.pause import InrPauseReq, InrPauseRep
         from protocol.message.process.play import InrPlayReq, InrPlayRep
         from protocol.message.process.playable_list import InrPlayableListReq, InrPlayableListRep
         from protocol.protocol_handler import ProtocolHandler
@@ -328,6 +338,116 @@ class ProtocolMeta:
                 },
                 inr_group_receive_handlers={
                     E_CATE.STREAMER: ProtocolHandler.inr_play_response_group,
+                },
+            ),
+        )
+
+        # ===== Pause 3계층 =====
+
+        # PD_PAUSE_REQ → REST_SERVER
+        cls._register(
+            E_PROTOCOL_ID.PD_PAUSE_REQ,
+            ProtocolEntry(
+                factory=lambda sender, receiver: PDPauseReq(
+                    protocol_id=E_PROTOCOL_ID.PD_PAUSE_REQ.value,
+                    sender=sender,
+                    receiver=receiver,
+                ),
+                decoder=PDPauseReq.from_json,
+                receive_handlers={
+                    E_CATE.REST_SERVER: ProtocolHandler.pd_pause_request,
+                },
+            ),
+        )
+
+        # PD_PAUSE_REP → REST_SERVER (socket.io broadcast)
+        cls._register(
+            E_PROTOCOL_ID.PD_PAUSE_REP,
+            ProtocolEntry(
+                factory=lambda sender, receiver, code, code_nm, reason: PDPauseRep(
+                    protocol_id=E_PROTOCOL_ID.PD_PAUSE_REP.value,
+                    sender=sender,
+                    receiver=receiver,
+                    code=code,
+                    code_nm=code_nm,
+                    reason=reason,
+                ),
+                decoder=PDPauseRep.from_json,
+                receive_handlers={
+                    E_CATE.REST_SERVER: ProtocolHandler.pd_pause_response,
+                },
+            ),
+        )
+
+        # PAUSE_REQ → BRIDGE / STREAMER / DOWNLOADER (Play와 동일 broadcast 패턴)
+        cls._register(
+            E_PROTOCOL_ID.PAUSE_REQ,
+            ProtocolEntry(
+                factory=lambda sender, receiver: PauseReq(
+                    protocol_id=E_PROTOCOL_ID.PAUSE_REQ.value,
+                    sender=sender,
+                    receiver=receiver,
+                ),
+                decoder=PauseReq.from_json,
+                receive_handlers={
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.pause_request,
+                    E_CATE.STREAMER: ProtocolHandler.pause_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.pause_request,
+                },
+            ),
+        )
+
+        # PAUSE_REP → MESSAGE_BRIDGE
+        cls._register(
+            E_PROTOCOL_ID.PAUSE_REP,
+            ProtocolEntry(
+                factory=lambda sender, receiver, response=None: PauseRep(
+                    protocol_id=E_PROTOCOL_ID.PAUSE_REP.value,
+                    sender=sender,
+                    receiver=receiver,
+                    response=response,
+                ),
+                decoder=PauseRep.from_json,
+                receive_handlers={
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.pause_response,
+                },
+            ),
+        )
+
+        # INR_PAUSE_REQ → STREAMER (Module) / DOWNLOADER (Module)
+        cls._register(
+            E_PROTOCOL_ID.INR_PAUSE_REQ,
+            ProtocolEntry(
+                factory=lambda sender, receiver: InrPauseReq(
+                    protocol_id=E_PROTOCOL_ID.INR_PAUSE_REQ.value,
+                    sender=sender,
+                    receiver=receiver,
+                ),
+                decoder=InrPauseReq.from_json,
+                receive_handlers={
+                    E_CATE.STREAMER: ProtocolHandler.inr_pause_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_pause_request,
+                },
+            ),
+        )
+
+        # INR_PAUSE_REP → STREAMER (Manager) / DOWNLOADER (Manager) + group
+        cls._register(
+            E_PROTOCOL_ID.INR_PAUSE_REP,
+            ProtocolEntry(
+                factory=lambda sender, receiver, response=None: InrPauseRep(
+                    protocol_id=E_PROTOCOL_ID.INR_PAUSE_REP.value,
+                    sender=sender,
+                    receiver=receiver,
+                    response=response,
+                ),
+                decoder=InrPauseRep.from_json,
+                receive_handlers={
+                    E_CATE.STREAMER: ProtocolHandler.inr_pause_response,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_pause_response,
+                },
+                inr_group_receive_handlers={
+                    E_CATE.STREAMER: ProtocolHandler.inr_pause_response_group,
                 },
             ),
         )


### PR DESCRIPTION
## Summary
- **Pause 패킷 3계층**: PD_PAUSE_REQ/REP(PD_400/401), PAUSE_REQ/REP(400/401), INR_PAUSE_REQ/REP(-400/-401) 6종 메시지 dataclass + ProtocolEntry 등록. Pause는 sender/receiver만 — 추가 필드 없음
- **ProtocolHandler dispatcher 7개 추가**: 6 normal(pd/imdg/inr × req/rep) + 1 group(inr_pause_response_group). 라우팅은 Play(#58) 패턴 복제 — PAUSE_REQ는 BRIDGE+STREAMER+DOWNLOADER 동시 broadcast
- **STREAMER PAUSE state 신설**: Manager/Module 양쪽에 WAIT/PLAY/PAUSE state. StreamerManager는 현 state PLAY일 때만 PAUSE 전이(아니면 INVALID_REQUEST). StreamerModule placeholder는 Pcaps/GStreamer 미이식 상태라 즉시 OK 응답 후 WAIT 복귀
- **handler 본체**: SocketIOProcess(PD↔IMDG 변환), MessageBridgeProcess(PAUSE_REP→PD_PAUSE_REP 변환). DOWNLOADER 쪽 handle_pause_*는 Download 흐름 미구현이라 NotImplementedError stub 유지

## Related Issues
- close #62