### PR TITLE
[feat] #64 Seek 패킷 3계층(PD/IMDG/INR) 추가

### DIFF
--- a/src/app/downloader/process/manager/manager.py
+++ b/src/app/downloader/process/manager/manager.py
@@ -128,3 +128,9 @@ class DownloaderManager(ImdgBusProcess):
 
     def handle_pause_response(self, packet) -> None:
         raise NotImplementedError
+
+    def handle_seek_request(self, packet) -> None:
+        raise NotImplementedError
+
+    def handle_seek_response(self, packet) -> None:
+        raise NotImplementedError

--- a/src/app/downloader/process/module/module.py
+++ b/src/app/downloader/process/module/module.py
@@ -81,3 +81,6 @@ class DownloaderModule(QueueControlProcess):
 
     def handle_pause_request(self, packet) -> None:
         raise NotImplementedError
+
+    def handle_seek_request(self, packet) -> None:
+        raise NotImplementedError

--- a/src/app/message_bridge/process/message_bridge_process.py
+++ b/src/app/message_bridge/process/message_bridge_process.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from common.process.imdg_bus_process import ImdgBusProcess
 from protocol.message.imdg.pause import PauseReq, PauseRep
 from protocol.message.imdg.play import PlayReq, PlayRep
+from protocol.message.imdg.seek import SeekReq, SeekRep
 from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
 from protocol.message.message import ResponseInfo
 from protocol.protocol_meta import E_PROTOCOL_ID, ProtocolMeta
@@ -106,6 +107,30 @@ class MessageBridgeProcess(ImdgBusProcess):
         response: ResponseInfo = packet.response or ResponseInfo()
         receiver = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
         factory = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PD_PAUSE_REP)
+        sender = ProtocolOwner.build(self.get_app_name(), self.name)
+
+        fwd_packet = factory(
+            sender,
+            receiver,
+            response.code,
+            response.code_nm,
+            response.reason,
+        )
+        envelope = ProtocolWrapper.get_protocol_wrapper(fwd_packet).get_protocol_packet_message()
+        self.send_message_imdg(envelope)
+
+    def handle_seek_request(self, packet: SeekReq) -> None:
+        # SEEK_REQ는 STREAMER도 broadcast로 받으므로 BRIDGE는 forward 불필요 — no-op.
+        pass
+
+    def handle_seek_response(self, packet: SeekRep) -> None:
+        """STREAMER → MESSAGE_BRIDGE로 들어온 SEEK_REP를 PD_SEEK_REP로 변환해 REST_SERVER로 IMDG 송신."""
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_owner import ProtocolOwner
+
+        response: ResponseInfo = packet.response or ResponseInfo()
+        receiver = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
+        factory = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PD_SEEK_REP)
         sender = ProtocolOwner.build(self.get_app_name(), self.name)
 
         fwd_packet = factory(

--- a/src/app/rest/process/socket_io_process.py
+++ b/src/app/rest/process/socket_io_process.py
@@ -8,6 +8,7 @@ from config.project_config import ProjectConfig
 from protocol.message.external.ui.pause import PDPauseReq, PDPauseRep
 from protocol.message.external.ui.play import PDPlayReq, PDPlayRep
 from protocol.message.external.ui.playable_list import PDPlayableListReq, PDPlayableListRep
+from protocol.message.external.ui.seek import PDSeekReq, PDSeekRep
 from protocol.message.message import IMessage
 from protocol.protocol_meta import E_PROTOCOL_ID, ProtocolMeta
 from protocol.protocol_owner import ProtocolOwner
@@ -100,4 +101,23 @@ class SocketIOProcess(ImdgBusProcess):
 
     def handle_pause_response(self, packet: PDPauseRep) -> None:
         """PD_PAUSE_REP를 socket.io로 broadcast."""
+        self.broadcast_to_clients(packet)
+
+    def handle_seek_request(self, packet: PDSeekReq) -> None:
+        from process_category.enum_category import E_CATE
+
+        sender = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
+        receiver = ProtocolOwner.build(E_CATE.STREAMER, E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER)
+
+        message = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.SEEK_REQ)(
+            sender,
+            receiver,
+            packet.start_time,
+        )
+
+        envelope = ProtocolWrapper.get_protocol_wrapper(message).get_protocol_packet_message()
+        self.send_message_imdg(envelope)
+
+    def handle_seek_response(self, packet: PDSeekRep) -> None:
+        """PD_SEEK_REP를 socket.io로 broadcast."""
         self.broadcast_to_clients(packet)

--- a/src/app/streamer/process/manager/manager.py
+++ b/src/app/streamer/process/manager/manager.py
@@ -6,6 +6,7 @@ from common.process.imdg_bus_process import ImdgBusProcess
 from protocol.inr_protocol_matcher.inr_pair_state import E_PROTOCOL_PAIR_STATE
 from protocol.message.imdg.pause import PauseReq
 from protocol.message.imdg.play import PlayReq
+from protocol.message.imdg.seek import SeekReq
 from protocol.message.message import IMessage
 
 from app.streamer.process.manager.state import (
@@ -119,6 +120,53 @@ class StreamerManager(ImdgBusProcess):
         else:
             self.send_message_rep_imdg(
                 E_PROTOCOL_ID.PAUSE_REP, bridge,
+                response=make_response_info(E_CODE.OK),
+            )
+
+        if self._state_component is not None:
+            self._state_component.change_state(E_STREAMER_MANAGER_STATE.WAIT)
+
+    def handle_seek_request(self, packet: SeekReq) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+        from protocol.protocol_owner import ProtocolOwner
+
+        # Seek은 PLAY 또는 PAUSE 중에 의미 있음 — WAIT일 때는 INVALID_REQUEST.
+        current = self.get_current_state_id()
+        if current not in (E_STREAMER_MANAGER_STATE.PLAY, E_STREAMER_MANAGER_STATE.PAUSE):
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.SEEK_REP,
+                ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE),
+                response=make_response_info(E_CODE.INVALID_REQUEST),
+            )
+            return
+
+        if self._state_component is not None:
+            self._state_component.change_state(E_STREAMER_MANAGER_STATE.SEEK, state_param_dto=packet)
+
+    def handle_seek_response(self, packet) -> None:
+        # 매처 경로(handle_seek_group_response)가 후처리 — 개별 handler는 no-op.
+        pass
+
+    def handle_seek_group_response(self, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+        from protocol.protocol_owner import ProtocolOwner
+
+        bridge = ProtocolOwner.build(
+            E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE
+        )
+
+        if pair_state == E_PROTOCOL_PAIR_STATE.ERROR:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.SEEK_REP, bridge,
+                response=make_response_info(E_CODE.INVALID_REQUEST, "module error"),
+            )
+        else:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.SEEK_REP, bridge,
                 response=make_response_info(E_CODE.OK),
             )
 

--- a/src/app/streamer/process/manager/state/__init__.py
+++ b/src/app/streamer/process/manager/state/__init__.py
@@ -2,6 +2,7 @@ from python_library.state import StateMap
 
 from app.streamer.process.manager.state.pause import PauseState
 from app.streamer.process.manager.state.play import PlayState
+from app.streamer.process.manager.state.seek import SeekState
 from app.streamer.process.manager.state.state_enum import E_STREAMER_MANAGER_STATE
 from app.streamer.process.manager.state.wait import WaitState
 
@@ -12,5 +13,6 @@ def build_state_map() -> StateMap:
         E_STREAMER_MANAGER_STATE.WAIT: WaitState(state_map, E_STREAMER_MANAGER_STATE.WAIT),
         E_STREAMER_MANAGER_STATE.PLAY: PlayState(state_map, E_STREAMER_MANAGER_STATE.PLAY),
         E_STREAMER_MANAGER_STATE.PAUSE: PauseState(state_map, E_STREAMER_MANAGER_STATE.PAUSE),
+        E_STREAMER_MANAGER_STATE.SEEK: SeekState(state_map, E_STREAMER_MANAGER_STATE.SEEK),
     }
     return state_map

--- a/src/app/streamer/process/manager/state/seek.py
+++ b/src/app/streamer/process/manager/state/seek.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_library.state import abState
+
+from protocol.message.imdg.seek import SeekReq
+
+if TYPE_CHECKING:
+    from app.streamer.process.manager.manager import StreamerManager
+
+
+class SeekState(abState):
+    owner: StreamerManager
+
+    def on_enter(self):
+        assert isinstance(self.state_param_dto, SeekReq)
+
+    def on_leave(self): pass
+
+    def on_proc_once(self):
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        assert isinstance(self.state_param_dto, SeekReq)
+
+        # 활성 sensor module list 추적은 후속 작업 — placeholder는 빈 리스트.
+        receivers: list[str] = []
+
+        self.owner.broadcast_message_req_inner_queue(
+            E_PROTOCOL_ID.INR_SEEK_REQ,
+            receivers,
+            self.state_param_dto.start_time,
+            rep_protocol_id=E_PROTOCOL_ID.INR_SEEK_REP,
+        )
+
+    def on_proc_every_frame(self): pass

--- a/src/app/streamer/process/manager/state/state_enum.py
+++ b/src/app/streamer/process/manager/state/state_enum.py
@@ -5,3 +5,4 @@ class E_STREAMER_MANAGER_STATE(IntEnum):
     WAIT = 0
     PLAY = 1
     PAUSE = 2
+    SEEK = 3

--- a/src/app/streamer/process/module/module.py
+++ b/src/app/streamer/process/module/module.py
@@ -5,6 +5,7 @@ from typing import Optional
 from common.process.queue_control_process import QueueControlProcess
 from protocol.message.process.pause import InrPauseReq
 from protocol.message.process.play import InrPlayReq
+from protocol.message.process.seek import InrSeekReq
 
 from app.streamer.process.module.state import (
     E_STREAMER_MODULE_STATE,
@@ -60,5 +61,13 @@ class StreamerModule(QueueControlProcess):
         if self._state_component is not None:
             self._state_component.change_state(
                 E_STREAMER_MODULE_STATE.PAUSE,
+                state_param_dto=packet,
+            )
+
+    def handle_seek_request(self, packet: InrSeekReq) -> None:
+        # placeholder — 실제 GStreamer seek 흐름 미이식. 어떤 state든 일단 SEEK 진입 후 즉시 OK.
+        if self._state_component is not None:
+            self._state_component.change_state(
+                E_STREAMER_MODULE_STATE.SEEK,
                 state_param_dto=packet,
             )

--- a/src/app/streamer/process/module/state/__init__.py
+++ b/src/app/streamer/process/module/state/__init__.py
@@ -2,6 +2,7 @@ from python_library.state import StateMap
 
 from app.streamer.process.module.state.pause import PauseState
 from app.streamer.process.module.state.play import PlayState
+from app.streamer.process.module.state.seek import SeekState
 from app.streamer.process.module.state.state_enum import E_STREAMER_MODULE_STATE
 from app.streamer.process.module.state.wait import WaitState
 
@@ -12,5 +13,6 @@ def build_state_map() -> StateMap:
         E_STREAMER_MODULE_STATE.WAIT: WaitState(state_map, E_STREAMER_MODULE_STATE.WAIT),
         E_STREAMER_MODULE_STATE.PLAY: PlayState(state_map, E_STREAMER_MODULE_STATE.PLAY),
         E_STREAMER_MODULE_STATE.PAUSE: PauseState(state_map, E_STREAMER_MODULE_STATE.PAUSE),
+        E_STREAMER_MODULE_STATE.SEEK: SeekState(state_map, E_STREAMER_MODULE_STATE.SEEK),
     }
     return state_map

--- a/src/app/streamer/process/module/state/seek.py
+++ b/src/app/streamer/process/module/state/seek.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_library.state import abState
+
+from protocol.message.process.seek import InrSeekReq
+
+if TYPE_CHECKING:
+    from app.streamer.process.module.module import StreamerModule
+
+
+class SeekState(abState):
+    """Pcaps/GStreamer 미이식 상태의 placeholder — 진입 즉시 OK 응답 후 WAIT 복귀."""
+    owner: StreamerModule
+
+    def on_enter(self):
+        assert isinstance(self.state_param_dto, InrSeekReq)
+
+    def on_leave(self): pass
+
+    def on_proc_once(self):
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        self.owner.send_message_rep_inner_queue(
+            E_PROTOCOL_ID.INR_SEEK_REP,
+            E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER,
+            response=make_response_info(E_CODE.OK),
+        )
+
+        from app.streamer.process.module.state.state_enum import E_STREAMER_MODULE_STATE
+        self.owner._state_component.change_state(E_STREAMER_MODULE_STATE.WAIT)
+
+    def on_proc_every_frame(self): pass

--- a/src/app/streamer/process/module/state/state_enum.py
+++ b/src/app/streamer/process/module/state/state_enum.py
@@ -5,3 +5,4 @@ class E_STREAMER_MODULE_STATE(IntEnum):
     WAIT = 0
     PLAY = 1
     PAUSE = 2
+    SEEK = 3

--- a/src/protocol/message/external/ui/seek.py
+++ b/src/protocol/message/external/ui/seek.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from protocol.message.external.external import pdPacket, pdResponsePacket
+
+
+@dataclass
+class PDSeekReq(pdPacket):
+    start_time: str = ""
+
+
+@dataclass
+class PDSeekRep(pdResponsePacket):
+    pass

--- a/src/protocol/message/imdg/seek.py
+++ b/src/protocol/message/imdg/seek.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from protocol.message.imdg.imdg import abImdgRequestMessage, abImdgResponseMessage
+
+
+@dataclass
+class SeekReq(abImdgRequestMessage):
+    start_time: str = ""
+
+
+@dataclass
+class SeekRep(abImdgResponseMessage):
+    pass

--- a/src/protocol/message/process/seek.py
+++ b/src/protocol/message/process/seek.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from protocol.message.process.process import abProcessRequestMessage, abProcessResponseMessage
+
+
+@dataclass
+class InrSeekReq(abProcessRequestMessage):
+    start_time: str = ""
+
+
+@dataclass
+class InrSeekRep(abProcessResponseMessage):
+    pass

--- a/src/protocol/protocol_handler.py
+++ b/src/protocol/protocol_handler.py
@@ -12,13 +12,16 @@ from protocol.inr_protocol_matcher.inr_pair_state import E_PROTOCOL_PAIR_STATE
 from protocol.message.external.ui.pause import PDPauseReq, PDPauseRep
 from protocol.message.external.ui.play import PDPlayReq, PDPlayRep
 from protocol.message.external.ui.playable_list import PDPlayableListReq, PDPlayableListRep
+from protocol.message.external.ui.seek import PDSeekReq, PDSeekRep
 from protocol.message.imdg.pause import PauseReq, PauseRep
 from protocol.message.imdg.play import PlayReq, PlayRep
 from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
+from protocol.message.imdg.seek import SeekReq, SeekRep
 from protocol.message.message import IMessage
 from protocol.message.process.pause import InrPauseReq, InrPauseRep
 from protocol.message.process.play import InrPlayReq, InrPlayRep
 from protocol.message.process.playable_list import InrPlayableListReq, InrPlayableListRep
+from protocol.message.process.seek import InrSeekReq, InrSeekRep
 from protocol.protocol_wrapper import ProtocolWrapper
 
 
@@ -56,6 +59,16 @@ class ProtocolHandler:
         assert isinstance(packet, PDPauseRep)
         process.handle_pause_response(packet)
 
+    @staticmethod
+    def pd_seek_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PDSeekReq)
+        process.handle_seek_request(packet)
+
+    @staticmethod
+    def pd_seek_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PDSeekRep)
+        process.handle_seek_response(packet)
+
     # ---------------------------
     # IMDG — 앱 간 통신
     # ---------------------------
@@ -88,6 +101,16 @@ class ProtocolHandler:
     def pause_response(process, wrapper: ProtocolWrapper, packet: IMessage):
         assert isinstance(packet, PauseRep)
         process.handle_pause_response(packet)
+
+    @staticmethod
+    def seek_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, SeekReq)
+        process.handle_seek_request(packet)
+
+    @staticmethod
+    def seek_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, SeekRep)
+        process.handle_seek_response(packet)
 
     # ---------------------------
     # PROCESS (INR) — 앱 내 통신
@@ -122,6 +145,16 @@ class ProtocolHandler:
         assert isinstance(packet, InrPauseRep)
         process.handle_pause_response(packet)
 
+    @staticmethod
+    def inr_seek_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, InrSeekReq)
+        process.handle_seek_request(packet)
+
+    @staticmethod
+    def inr_seek_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, InrSeekRep)
+        process.handle_seek_response(packet)
+
     # ---------------------------
     # Group dispatchers — 시그니처 다름 (process, pair_state, packets)
     # ---------------------------
@@ -136,3 +169,7 @@ class ProtocolHandler:
     @staticmethod
     def inr_pause_response_group(process, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]):
         process.handle_pause_group_response(pair_state, packets)
+
+    @staticmethod
+    def inr_seek_response_group(process, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]):
+        process.handle_seek_group_response(pair_state, packets)

--- a/src/protocol/protocol_meta.py
+++ b/src/protocol/protocol_meta.py
@@ -39,6 +39,13 @@ class E_PROTOCOL_ID(Enum):
     INR_PAUSE_REQ = "-400"
     INR_PAUSE_REP = "-401"
 
+    PD_SEEK_REQ = "PD_500"
+    PD_SEEK_REP = "PD_501"
+    SEEK_REQ = "500"
+    SEEK_REP = "501"
+    INR_SEEK_REQ = "-500"
+    INR_SEEK_REP = "-501"
+
 
 @dataclass(frozen=True)
 class ProtocolEntry:
@@ -86,12 +93,15 @@ class ProtocolMeta:
         from protocol.message.external.ui.pause import PDPauseReq, PDPauseRep
         from protocol.message.external.ui.play import PDPlayReq, PDPlayRep
         from protocol.message.external.ui.playable_list import PDPlayableListReq, PDPlayableListRep
+        from protocol.message.external.ui.seek import PDSeekReq, PDSeekRep
         from protocol.message.imdg.pause import PauseReq, PauseRep
         from protocol.message.imdg.play import PlayReq, PlayRep
         from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
+        from protocol.message.imdg.seek import SeekReq, SeekRep
         from protocol.message.process.pause import InrPauseReq, InrPauseRep
         from protocol.message.process.play import InrPlayReq, InrPlayRep
         from protocol.message.process.playable_list import InrPlayableListReq, InrPlayableListRep
+        from protocol.message.process.seek import InrSeekReq, InrSeekRep
         from protocol.protocol_handler import ProtocolHandler
 
         # ===== PlayableList 3계층 =====
@@ -448,6 +458,119 @@ class ProtocolMeta:
                 },
                 inr_group_receive_handlers={
                     E_CATE.STREAMER: ProtocolHandler.inr_pause_response_group,
+                },
+            ),
+        )
+
+        # ===== Seek 3계층 =====
+
+        # PD_SEEK_REQ → REST_SERVER
+        cls._register(
+            E_PROTOCOL_ID.PD_SEEK_REQ,
+            ProtocolEntry(
+                factory=lambda sender, receiver, start_time: PDSeekReq(
+                    protocol_id=E_PROTOCOL_ID.PD_SEEK_REQ.value,
+                    sender=sender,
+                    receiver=receiver,
+                    start_time=start_time,
+                ),
+                decoder=PDSeekReq.from_json,
+                receive_handlers={
+                    E_CATE.REST_SERVER: ProtocolHandler.pd_seek_request,
+                },
+            ),
+        )
+
+        # PD_SEEK_REP → REST_SERVER (socket.io broadcast)
+        cls._register(
+            E_PROTOCOL_ID.PD_SEEK_REP,
+            ProtocolEntry(
+                factory=lambda sender, receiver, code, code_nm, reason: PDSeekRep(
+                    protocol_id=E_PROTOCOL_ID.PD_SEEK_REP.value,
+                    sender=sender,
+                    receiver=receiver,
+                    code=code,
+                    code_nm=code_nm,
+                    reason=reason,
+                ),
+                decoder=PDSeekRep.from_json,
+                receive_handlers={
+                    E_CATE.REST_SERVER: ProtocolHandler.pd_seek_response,
+                },
+            ),
+        )
+
+        # SEEK_REQ → BRIDGE / STREAMER / DOWNLOADER
+        cls._register(
+            E_PROTOCOL_ID.SEEK_REQ,
+            ProtocolEntry(
+                factory=lambda sender, receiver, start_time: SeekReq(
+                    protocol_id=E_PROTOCOL_ID.SEEK_REQ.value,
+                    sender=sender,
+                    receiver=receiver,
+                    start_time=start_time,
+                ),
+                decoder=SeekReq.from_json,
+                receive_handlers={
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.seek_request,
+                    E_CATE.STREAMER: ProtocolHandler.seek_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.seek_request,
+                },
+            ),
+        )
+
+        # SEEK_REP → MESSAGE_BRIDGE
+        cls._register(
+            E_PROTOCOL_ID.SEEK_REP,
+            ProtocolEntry(
+                factory=lambda sender, receiver, response=None: SeekRep(
+                    protocol_id=E_PROTOCOL_ID.SEEK_REP.value,
+                    sender=sender,
+                    receiver=receiver,
+                    response=response,
+                ),
+                decoder=SeekRep.from_json,
+                receive_handlers={
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.seek_response,
+                },
+            ),
+        )
+
+        # INR_SEEK_REQ → STREAMER (Module) / DOWNLOADER (Module)
+        cls._register(
+            E_PROTOCOL_ID.INR_SEEK_REQ,
+            ProtocolEntry(
+                factory=lambda sender, receiver, start_time: InrSeekReq(
+                    protocol_id=E_PROTOCOL_ID.INR_SEEK_REQ.value,
+                    sender=sender,
+                    receiver=receiver,
+                    start_time=start_time,
+                ),
+                decoder=InrSeekReq.from_json,
+                receive_handlers={
+                    E_CATE.STREAMER: ProtocolHandler.inr_seek_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_seek_request,
+                },
+            ),
+        )
+
+        # INR_SEEK_REP → STREAMER (Manager) / DOWNLOADER (Manager) + group
+        cls._register(
+            E_PROTOCOL_ID.INR_SEEK_REP,
+            ProtocolEntry(
+                factory=lambda sender, receiver, response=None: InrSeekRep(
+                    protocol_id=E_PROTOCOL_ID.INR_SEEK_REP.value,
+                    sender=sender,
+                    receiver=receiver,
+                    response=response,
+                ),
+                decoder=InrSeekRep.from_json,
+                receive_handlers={
+                    E_CATE.STREAMER: ProtocolHandler.inr_seek_response,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_seek_response,
+                },
+                inr_group_receive_handlers={
+                    E_CATE.STREAMER: ProtocolHandler.inr_seek_response_group,
                 },
             ),
         )


### PR DESCRIPTION
## Summary
- **Seek 패킷 3계층**: PD_SEEK_REQ/REP(PD_500/501), SEEK_REQ/REP(500/501), INR_SEEK_REQ/REP(-500/-501) 6종 메시지 dataclass + ProtocolEntry 등록. Req 필드는 `start_time(str)` — 점프할 시각
- **ProtocolHandler dispatcher 7개 추가**: 6 normal + 1 group(inr_seek_response_group). 라우팅은 Play/Pause와 동일 — SEEK_REQ는 BRIDGE+STREAMER+DOWNLOADER broadcast
- **STREAMER SEEK state 신설**: Manager/Module 양쪽 WAIT/PLAY/PAUSE → WAIT/PLAY/PAUSE/SEEK. `StreamerManager.handle_seek_request`은 현 state가 PLAY 또는 PAUSE일 때만 SEEK 전이(아니면 INVALID_REQUEST). StreamerModule placeholder는 Pcaps/GStreamer 미이식 상태라 즉시 SEEK 진입 후 OK 응답
- **handler 본체**: SocketIOProcess(PD↔IMDG 변환), MessageBridgeProcess(SEEK_REP→PD_SEEK_REP 변환). DOWNLOADER 쪽 handle_seek_*는 Download 흐름 미구현이라 NotImplementedError stub

## Related Issues
- close #64