### PR TITLE
[feat] #66 Close 패킷 3계층(PD/IMDG/INR) 추가

### DIFF
--- a/src/app/downloader/process/manager/manager.py
+++ b/src/app/downloader/process/manager/manager.py
@@ -134,3 +134,9 @@ class DownloaderManager(ImdgBusProcess):
 
     def handle_seek_response(self, packet) -> None:
         raise NotImplementedError
+
+    def handle_close_request(self, packet) -> None:
+        raise NotImplementedError
+
+    def handle_close_response(self, packet) -> None:
+        raise NotImplementedError

--- a/src/app/downloader/process/module/module.py
+++ b/src/app/downloader/process/module/module.py
@@ -84,3 +84,6 @@ class DownloaderModule(QueueControlProcess):
 
     def handle_seek_request(self, packet) -> None:
         raise NotImplementedError
+
+    def handle_close_request(self, packet) -> None:
+        raise NotImplementedError

--- a/src/app/message_bridge/process/message_bridge_process.py
+++ b/src/app/message_bridge/process/message_bridge_process.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from common.process.imdg_bus_process import ImdgBusProcess
+from protocol.message.imdg.close import CloseReq, CloseRep
 from protocol.message.imdg.pause import PauseReq, PauseRep
 from protocol.message.imdg.play import PlayReq, PlayRep
 from protocol.message.imdg.seek import SeekReq, SeekRep
@@ -131,6 +132,30 @@ class MessageBridgeProcess(ImdgBusProcess):
         response: ResponseInfo = packet.response or ResponseInfo()
         receiver = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
         factory = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PD_SEEK_REP)
+        sender = ProtocolOwner.build(self.get_app_name(), self.name)
+
+        fwd_packet = factory(
+            sender,
+            receiver,
+            response.code,
+            response.code_nm,
+            response.reason,
+        )
+        envelope = ProtocolWrapper.get_protocol_wrapper(fwd_packet).get_protocol_packet_message()
+        self.send_message_imdg(envelope)
+
+    def handle_close_request(self, packet: CloseReq) -> None:
+        # CLOSE_REQ는 STREAMER도 broadcast로 받으므로 BRIDGE는 forward 불필요 — no-op.
+        pass
+
+    def handle_close_response(self, packet: CloseRep) -> None:
+        """STREAMER → MESSAGE_BRIDGE로 들어온 CLOSE_REP를 PD_CLOSE_REP로 변환해 REST_SERVER로 IMDG 송신."""
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_owner import ProtocolOwner
+
+        response: ResponseInfo = packet.response or ResponseInfo()
+        receiver = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
+        factory = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PD_CLOSE_REP)
         sender = ProtocolOwner.build(self.get_app_name(), self.name)
 
         fwd_packet = factory(

--- a/src/app/rest/process/socket_io_process.py
+++ b/src/app/rest/process/socket_io_process.py
@@ -5,6 +5,7 @@ import asyncio
 from app.rest.websocket_server import SocketIOServer
 from common.process.imdg_bus_process import ImdgBusProcess
 from config.project_config import ProjectConfig
+from protocol.message.external.ui.close import PDCloseReq, PDCloseRep
 from protocol.message.external.ui.pause import PDPauseReq, PDPauseRep
 from protocol.message.external.ui.play import PDPlayReq, PDPlayRep
 from protocol.message.external.ui.playable_list import PDPlayableListReq, PDPlayableListRep
@@ -120,4 +121,22 @@ class SocketIOProcess(ImdgBusProcess):
 
     def handle_seek_response(self, packet: PDSeekRep) -> None:
         """PD_SEEK_REP를 socket.io로 broadcast."""
+        self.broadcast_to_clients(packet)
+
+    def handle_close_request(self, packet: PDCloseReq) -> None:
+        from process_category.enum_category import E_CATE
+
+        sender = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
+        receiver = ProtocolOwner.build(E_CATE.STREAMER, E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER)
+
+        message = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.CLOSE_REQ)(
+            sender,
+            receiver,
+        )
+
+        envelope = ProtocolWrapper.get_protocol_wrapper(message).get_protocol_packet_message()
+        self.send_message_imdg(envelope)
+
+    def handle_close_response(self, packet: PDCloseRep) -> None:
+        """PD_CLOSE_REP를 socket.io로 broadcast."""
         self.broadcast_to_clients(packet)

--- a/src/app/streamer/process/manager/manager.py
+++ b/src/app/streamer/process/manager/manager.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from common.process.imdg_bus_process import ImdgBusProcess
 from protocol.inr_protocol_matcher.inr_pair_state import E_PROTOCOL_PAIR_STATE
+from protocol.message.imdg.close import CloseReq
 from protocol.message.imdg.pause import PauseReq
 from protocol.message.imdg.play import PlayReq
 from protocol.message.imdg.seek import SeekReq
@@ -167,6 +168,39 @@ class StreamerManager(ImdgBusProcess):
         else:
             self.send_message_rep_imdg(
                 E_PROTOCOL_ID.SEEK_REP, bridge,
+                response=make_response_info(E_CODE.OK),
+            )
+
+        if self._state_component is not None:
+            self._state_component.change_state(E_STREAMER_MANAGER_STATE.WAIT)
+
+    def handle_close_request(self, packet: CloseReq) -> None:
+        # Close는 어떤 state에서든 의미 있음(현재 활성 흐름 종료) — state 체크 생략하고 일단 CLOSE 진입.
+        if self._state_component is not None:
+            self._state_component.change_state(E_STREAMER_MANAGER_STATE.CLOSE, state_param_dto=packet)
+
+    def handle_close_response(self, packet) -> None:
+        # 매처 경로(handle_close_group_response)가 후처리 — 개별 handler는 no-op.
+        pass
+
+    def handle_close_group_response(self, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+        from protocol.protocol_owner import ProtocolOwner
+
+        bridge = ProtocolOwner.build(
+            E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE
+        )
+
+        if pair_state == E_PROTOCOL_PAIR_STATE.ERROR:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.CLOSE_REP, bridge,
+                response=make_response_info(E_CODE.INVALID_REQUEST, "module error"),
+            )
+        else:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.CLOSE_REP, bridge,
                 response=make_response_info(E_CODE.OK),
             )
 

--- a/src/app/streamer/process/manager/state/__init__.py
+++ b/src/app/streamer/process/manager/state/__init__.py
@@ -1,5 +1,6 @@
 from python_library.state import StateMap
 
+from app.streamer.process.manager.state.close import CloseState
 from app.streamer.process.manager.state.pause import PauseState
 from app.streamer.process.manager.state.play import PlayState
 from app.streamer.process.manager.state.seek import SeekState
@@ -14,5 +15,6 @@ def build_state_map() -> StateMap:
         E_STREAMER_MANAGER_STATE.PLAY: PlayState(state_map, E_STREAMER_MANAGER_STATE.PLAY),
         E_STREAMER_MANAGER_STATE.PAUSE: PauseState(state_map, E_STREAMER_MANAGER_STATE.PAUSE),
         E_STREAMER_MANAGER_STATE.SEEK: SeekState(state_map, E_STREAMER_MANAGER_STATE.SEEK),
+        E_STREAMER_MANAGER_STATE.CLOSE: CloseState(state_map, E_STREAMER_MANAGER_STATE.CLOSE),
     }
     return state_map

--- a/src/app/streamer/process/manager/state/close.py
+++ b/src/app/streamer/process/manager/state/close.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_library.state import abState
+
+from protocol.message.imdg.close import CloseReq
+
+if TYPE_CHECKING:
+    from app.streamer.process.manager.manager import StreamerManager
+
+
+class CloseState(abState):
+    owner: StreamerManager
+
+    def on_enter(self):
+        assert isinstance(self.state_param_dto, CloseReq)
+
+    def on_leave(self): pass
+
+    def on_proc_once(self):
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        # 활성 sensor module list 추적은 후속 작업 — placeholder는 빈 리스트.
+        receivers: list[str] = []
+
+        self.owner.broadcast_message_req_inner_queue(
+            E_PROTOCOL_ID.INR_CLOSE_REQ,
+            receivers,
+            rep_protocol_id=E_PROTOCOL_ID.INR_CLOSE_REP,
+        )
+
+    def on_proc_every_frame(self): pass

--- a/src/app/streamer/process/manager/state/state_enum.py
+++ b/src/app/streamer/process/manager/state/state_enum.py
@@ -6,3 +6,4 @@ class E_STREAMER_MANAGER_STATE(IntEnum):
     PLAY = 1
     PAUSE = 2
     SEEK = 3
+    CLOSE = 4

--- a/src/app/streamer/process/module/module.py
+++ b/src/app/streamer/process/module/module.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 from common.process.queue_control_process import QueueControlProcess
+from protocol.message.process.close import InrCloseReq
 from protocol.message.process.pause import InrPauseReq
 from protocol.message.process.play import InrPlayReq
 from protocol.message.process.seek import InrSeekReq
@@ -69,5 +70,13 @@ class StreamerModule(QueueControlProcess):
         if self._state_component is not None:
             self._state_component.change_state(
                 E_STREAMER_MODULE_STATE.SEEK,
+                state_param_dto=packet,
+            )
+
+    def handle_close_request(self, packet: InrCloseReq) -> None:
+        # placeholder — 실제 GStreamer close 흐름 미이식. 어떤 state든 일단 CLOSE 진입 후 즉시 OK.
+        if self._state_component is not None:
+            self._state_component.change_state(
+                E_STREAMER_MODULE_STATE.CLOSE,
                 state_param_dto=packet,
             )

--- a/src/app/streamer/process/module/state/__init__.py
+++ b/src/app/streamer/process/module/state/__init__.py
@@ -1,5 +1,6 @@
 from python_library.state import StateMap
 
+from app.streamer.process.module.state.close import CloseState
 from app.streamer.process.module.state.pause import PauseState
 from app.streamer.process.module.state.play import PlayState
 from app.streamer.process.module.state.seek import SeekState
@@ -14,5 +15,6 @@ def build_state_map() -> StateMap:
         E_STREAMER_MODULE_STATE.PLAY: PlayState(state_map, E_STREAMER_MODULE_STATE.PLAY),
         E_STREAMER_MODULE_STATE.PAUSE: PauseState(state_map, E_STREAMER_MODULE_STATE.PAUSE),
         E_STREAMER_MODULE_STATE.SEEK: SeekState(state_map, E_STREAMER_MODULE_STATE.SEEK),
+        E_STREAMER_MODULE_STATE.CLOSE: CloseState(state_map, E_STREAMER_MODULE_STATE.CLOSE),
     }
     return state_map

--- a/src/app/streamer/process/module/state/close.py
+++ b/src/app/streamer/process/module/state/close.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_library.state import abState
+
+from protocol.message.process.close import InrCloseReq
+
+if TYPE_CHECKING:
+    from app.streamer.process.module.module import StreamerModule
+
+
+class CloseState(abState):
+    """Pcaps/GStreamer 미이식 상태의 placeholder — 진입 즉시 OK 응답 후 WAIT 복귀."""
+    owner: StreamerModule
+
+    def on_enter(self):
+        assert isinstance(self.state_param_dto, InrCloseReq)
+
+    def on_leave(self): pass
+
+    def on_proc_once(self):
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        self.owner.send_message_rep_inner_queue(
+            E_PROTOCOL_ID.INR_CLOSE_REP,
+            E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER,
+            response=make_response_info(E_CODE.OK),
+        )
+
+        from app.streamer.process.module.state.state_enum import E_STREAMER_MODULE_STATE
+        self.owner._state_component.change_state(E_STREAMER_MODULE_STATE.WAIT)
+
+    def on_proc_every_frame(self): pass

--- a/src/app/streamer/process/module/state/state_enum.py
+++ b/src/app/streamer/process/module/state/state_enum.py
@@ -6,3 +6,4 @@ class E_STREAMER_MODULE_STATE(IntEnum):
     PLAY = 1
     PAUSE = 2
     SEEK = 3
+    CLOSE = 4

--- a/src/protocol/message/external/ui/close.py
+++ b/src/protocol/message/external/ui/close.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from protocol.message.external.external import pdPacket, pdResponsePacket
+
+
+@dataclass
+class PDCloseReq(pdPacket):
+    pass
+
+
+@dataclass
+class PDCloseRep(pdResponsePacket):
+    pass

--- a/src/protocol/message/imdg/close.py
+++ b/src/protocol/message/imdg/close.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from protocol.message.imdg.imdg import abImdgRequestMessage, abImdgResponseMessage
+
+
+@dataclass
+class CloseReq(abImdgRequestMessage):
+    pass
+
+
+@dataclass
+class CloseRep(abImdgResponseMessage):
+    pass

--- a/src/protocol/message/process/close.py
+++ b/src/protocol/message/process/close.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from protocol.message.process.process import abProcessRequestMessage, abProcessResponseMessage
+
+
+@dataclass
+class InrCloseReq(abProcessRequestMessage):
+    pass
+
+
+@dataclass
+class InrCloseRep(abProcessResponseMessage):
+    pass

--- a/src/protocol/protocol_handler.py
+++ b/src/protocol/protocol_handler.py
@@ -9,15 +9,18 @@ group dispatcher는 시그니처가 다른 (process, pair_state, packets).
 from __future__ import annotations
 
 from protocol.inr_protocol_matcher.inr_pair_state import E_PROTOCOL_PAIR_STATE
+from protocol.message.external.ui.close import PDCloseReq, PDCloseRep
 from protocol.message.external.ui.pause import PDPauseReq, PDPauseRep
 from protocol.message.external.ui.play import PDPlayReq, PDPlayRep
 from protocol.message.external.ui.playable_list import PDPlayableListReq, PDPlayableListRep
 from protocol.message.external.ui.seek import PDSeekReq, PDSeekRep
+from protocol.message.imdg.close import CloseReq, CloseRep
 from protocol.message.imdg.pause import PauseReq, PauseRep
 from protocol.message.imdg.play import PlayReq, PlayRep
 from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
 from protocol.message.imdg.seek import SeekReq, SeekRep
 from protocol.message.message import IMessage
+from protocol.message.process.close import InrCloseReq, InrCloseRep
 from protocol.message.process.pause import InrPauseReq, InrPauseRep
 from protocol.message.process.play import InrPlayReq, InrPlayRep
 from protocol.message.process.playable_list import InrPlayableListReq, InrPlayableListRep
@@ -69,6 +72,16 @@ class ProtocolHandler:
         assert isinstance(packet, PDSeekRep)
         process.handle_seek_response(packet)
 
+    @staticmethod
+    def pd_close_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PDCloseReq)
+        process.handle_close_request(packet)
+
+    @staticmethod
+    def pd_close_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PDCloseRep)
+        process.handle_close_response(packet)
+
     # ---------------------------
     # IMDG — 앱 간 통신
     # ---------------------------
@@ -111,6 +124,16 @@ class ProtocolHandler:
     def seek_response(process, wrapper: ProtocolWrapper, packet: IMessage):
         assert isinstance(packet, SeekRep)
         process.handle_seek_response(packet)
+
+    @staticmethod
+    def close_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, CloseReq)
+        process.handle_close_request(packet)
+
+    @staticmethod
+    def close_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, CloseRep)
+        process.handle_close_response(packet)
 
     # ---------------------------
     # PROCESS (INR) — 앱 내 통신
@@ -155,6 +178,16 @@ class ProtocolHandler:
         assert isinstance(packet, InrSeekRep)
         process.handle_seek_response(packet)
 
+    @staticmethod
+    def inr_close_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, InrCloseReq)
+        process.handle_close_request(packet)
+
+    @staticmethod
+    def inr_close_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, InrCloseRep)
+        process.handle_close_response(packet)
+
     # ---------------------------
     # Group dispatchers — 시그니처 다름 (process, pair_state, packets)
     # ---------------------------
@@ -173,3 +206,7 @@ class ProtocolHandler:
     @staticmethod
     def inr_seek_response_group(process, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]):
         process.handle_seek_group_response(pair_state, packets)
+
+    @staticmethod
+    def inr_close_response_group(process, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]):
+        process.handle_close_group_response(pair_state, packets)

--- a/src/protocol/protocol_meta.py
+++ b/src/protocol/protocol_meta.py
@@ -46,6 +46,13 @@ class E_PROTOCOL_ID(Enum):
     INR_SEEK_REQ = "-500"
     INR_SEEK_REP = "-501"
 
+    PD_CLOSE_REQ = "PD_300"
+    PD_CLOSE_REP = "PD_301"
+    CLOSE_REQ = "300"
+    CLOSE_REP = "301"
+    INR_CLOSE_REQ = "-300"
+    INR_CLOSE_REP = "-301"
+
 
 @dataclass(frozen=True)
 class ProtocolEntry:
@@ -90,14 +97,17 @@ class ProtocolMeta:
     @classmethod
     def _register_protocols(cls) -> None:
         from process_category.enum_category import E_CATE
+        from protocol.message.external.ui.close import PDCloseReq, PDCloseRep
         from protocol.message.external.ui.pause import PDPauseReq, PDPauseRep
         from protocol.message.external.ui.play import PDPlayReq, PDPlayRep
         from protocol.message.external.ui.playable_list import PDPlayableListReq, PDPlayableListRep
         from protocol.message.external.ui.seek import PDSeekReq, PDSeekRep
+        from protocol.message.imdg.close import CloseReq, CloseRep
         from protocol.message.imdg.pause import PauseReq, PauseRep
         from protocol.message.imdg.play import PlayReq, PlayRep
         from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
         from protocol.message.imdg.seek import SeekReq, SeekRep
+        from protocol.message.process.close import InrCloseReq, InrCloseRep
         from protocol.message.process.pause import InrPauseReq, InrPauseRep
         from protocol.message.process.play import InrPlayReq, InrPlayRep
         from protocol.message.process.playable_list import InrPlayableListReq, InrPlayableListRep
@@ -571,6 +581,116 @@ class ProtocolMeta:
                 },
                 inr_group_receive_handlers={
                     E_CATE.STREAMER: ProtocolHandler.inr_seek_response_group,
+                },
+            ),
+        )
+
+        # ===== Close 3계층 =====
+
+        # PD_CLOSE_REQ → REST_SERVER
+        cls._register(
+            E_PROTOCOL_ID.PD_CLOSE_REQ,
+            ProtocolEntry(
+                factory=lambda sender, receiver: PDCloseReq(
+                    protocol_id=E_PROTOCOL_ID.PD_CLOSE_REQ.value,
+                    sender=sender,
+                    receiver=receiver,
+                ),
+                decoder=PDCloseReq.from_json,
+                receive_handlers={
+                    E_CATE.REST_SERVER: ProtocolHandler.pd_close_request,
+                },
+            ),
+        )
+
+        # PD_CLOSE_REP → REST_SERVER (socket.io broadcast)
+        cls._register(
+            E_PROTOCOL_ID.PD_CLOSE_REP,
+            ProtocolEntry(
+                factory=lambda sender, receiver, code, code_nm, reason: PDCloseRep(
+                    protocol_id=E_PROTOCOL_ID.PD_CLOSE_REP.value,
+                    sender=sender,
+                    receiver=receiver,
+                    code=code,
+                    code_nm=code_nm,
+                    reason=reason,
+                ),
+                decoder=PDCloseRep.from_json,
+                receive_handlers={
+                    E_CATE.REST_SERVER: ProtocolHandler.pd_close_response,
+                },
+            ),
+        )
+
+        # CLOSE_REQ → BRIDGE / STREAMER / DOWNLOADER
+        cls._register(
+            E_PROTOCOL_ID.CLOSE_REQ,
+            ProtocolEntry(
+                factory=lambda sender, receiver: CloseReq(
+                    protocol_id=E_PROTOCOL_ID.CLOSE_REQ.value,
+                    sender=sender,
+                    receiver=receiver,
+                ),
+                decoder=CloseReq.from_json,
+                receive_handlers={
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.close_request,
+                    E_CATE.STREAMER: ProtocolHandler.close_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.close_request,
+                },
+            ),
+        )
+
+        # CLOSE_REP → MESSAGE_BRIDGE
+        cls._register(
+            E_PROTOCOL_ID.CLOSE_REP,
+            ProtocolEntry(
+                factory=lambda sender, receiver, response=None: CloseRep(
+                    protocol_id=E_PROTOCOL_ID.CLOSE_REP.value,
+                    sender=sender,
+                    receiver=receiver,
+                    response=response,
+                ),
+                decoder=CloseRep.from_json,
+                receive_handlers={
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.close_response,
+                },
+            ),
+        )
+
+        # INR_CLOSE_REQ → STREAMER (Module) / DOWNLOADER (Module)
+        cls._register(
+            E_PROTOCOL_ID.INR_CLOSE_REQ,
+            ProtocolEntry(
+                factory=lambda sender, receiver: InrCloseReq(
+                    protocol_id=E_PROTOCOL_ID.INR_CLOSE_REQ.value,
+                    sender=sender,
+                    receiver=receiver,
+                ),
+                decoder=InrCloseReq.from_json,
+                receive_handlers={
+                    E_CATE.STREAMER: ProtocolHandler.inr_close_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_close_request,
+                },
+            ),
+        )
+
+        # INR_CLOSE_REP → STREAMER (Manager) / DOWNLOADER (Manager) + group
+        cls._register(
+            E_PROTOCOL_ID.INR_CLOSE_REP,
+            ProtocolEntry(
+                factory=lambda sender, receiver, response=None: InrCloseRep(
+                    protocol_id=E_PROTOCOL_ID.INR_CLOSE_REP.value,
+                    sender=sender,
+                    receiver=receiver,
+                    response=response,
+                ),
+                decoder=InrCloseRep.from_json,
+                receive_handlers={
+                    E_CATE.STREAMER: ProtocolHandler.inr_close_response,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_close_response,
+                },
+                inr_group_receive_handlers={
+                    E_CATE.STREAMER: ProtocolHandler.inr_close_response_group,
                 },
             ),
         )


### PR DESCRIPTION
## Summary
- **Close 패킷 3계층**: PD_CLOSE_REQ/REP(PD_300/301), CLOSE_REQ/REP(300/301), INR_CLOSE_REQ/REP(-300/-301) 6종 메시지 dataclass + ProtocolEntry 등록. Pause와 동일하게 sender/receiver만 — 추가 필드 없음
- **ProtocolHandler dispatcher 7개 추가**: 6 normal + 1 group(inr_close_response_group). 라우팅은 Play/Pause/Seek와 동일 — CLOSE_REQ는 BRIDGE+STREAMER+DOWNLOADER broadcast
- **STREAMER CLOSE state 신설**: Manager/Module 양쪽 WAIT/PLAY/PAUSE/SEEK → +CLOSE. `StreamerManager.handle_close_request`은 state 체크 없이 무조건 CLOSE 진입(종료 명령은 어느 시점에도 의미 있음). StreamerModule placeholder는 즉시 CLOSE 진입 후 OK 응답
- **handler 본체**: SocketIOProcess(PD↔IMDG 변환), MessageBridgeProcess(CLOSE_REP→PD_CLOSE_REP 변환). DOWNLOADER 쪽 handle_close_*는 Download 흐름 미구현이라 NotImplementedError stub

## Related Issues
- close #66