### PR TITLE
[feat] #68 Stop 패킷 3계층(PD/IMDG/INR) 추가 — Play lifecycle 5종 마무리

### DIFF
--- a/src/app/downloader/process/manager/manager.py
+++ b/src/app/downloader/process/manager/manager.py
@@ -140,3 +140,9 @@ class DownloaderManager(ImdgBusProcess):
 
     def handle_close_response(self, packet) -> None:
         raise NotImplementedError
+
+    def handle_stop_request(self, packet) -> None:
+        raise NotImplementedError
+
+    def handle_stop_response(self, packet) -> None:
+        raise NotImplementedError

--- a/src/app/downloader/process/module/module.py
+++ b/src/app/downloader/process/module/module.py
@@ -87,3 +87,6 @@ class DownloaderModule(QueueControlProcess):
 
     def handle_close_request(self, packet) -> None:
         raise NotImplementedError
+
+    def handle_stop_request(self, packet) -> None:
+        raise NotImplementedError

--- a/src/app/message_bridge/process/message_bridge_process.py
+++ b/src/app/message_bridge/process/message_bridge_process.py
@@ -5,6 +5,7 @@ from protocol.message.imdg.close import CloseReq, CloseRep
 from protocol.message.imdg.pause import PauseReq, PauseRep
 from protocol.message.imdg.play import PlayReq, PlayRep
 from protocol.message.imdg.seek import SeekReq, SeekRep
+from protocol.message.imdg.stop import StopReq, StopRep
 from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
 from protocol.message.message import ResponseInfo
 from protocol.protocol_meta import E_PROTOCOL_ID, ProtocolMeta
@@ -156,6 +157,30 @@ class MessageBridgeProcess(ImdgBusProcess):
         response: ResponseInfo = packet.response or ResponseInfo()
         receiver = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
         factory = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PD_CLOSE_REP)
+        sender = ProtocolOwner.build(self.get_app_name(), self.name)
+
+        fwd_packet = factory(
+            sender,
+            receiver,
+            response.code,
+            response.code_nm,
+            response.reason,
+        )
+        envelope = ProtocolWrapper.get_protocol_wrapper(fwd_packet).get_protocol_packet_message()
+        self.send_message_imdg(envelope)
+
+    def handle_stop_request(self, packet: StopReq) -> None:
+        # STOP_REQ는 STREAMER도 broadcast로 받으므로 BRIDGE는 forward 불필요 — no-op.
+        pass
+
+    def handle_stop_response(self, packet: StopRep) -> None:
+        """STREAMER → MESSAGE_BRIDGE로 들어온 STOP_REP를 PD_STOP_REP로 변환해 REST_SERVER로 IMDG 송신."""
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_owner import ProtocolOwner
+
+        response: ResponseInfo = packet.response or ResponseInfo()
+        receiver = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
+        factory = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PD_STOP_REP)
         sender = ProtocolOwner.build(self.get_app_name(), self.name)
 
         fwd_packet = factory(

--- a/src/app/rest/process/socket_io_process.py
+++ b/src/app/rest/process/socket_io_process.py
@@ -10,6 +10,7 @@ from protocol.message.external.ui.pause import PDPauseReq, PDPauseRep
 from protocol.message.external.ui.play import PDPlayReq, PDPlayRep
 from protocol.message.external.ui.playable_list import PDPlayableListReq, PDPlayableListRep
 from protocol.message.external.ui.seek import PDSeekReq, PDSeekRep
+from protocol.message.external.ui.stop import PDStopReq, PDStopRep
 from protocol.message.message import IMessage
 from protocol.protocol_meta import E_PROTOCOL_ID, ProtocolMeta
 from protocol.protocol_owner import ProtocolOwner
@@ -139,4 +140,22 @@ class SocketIOProcess(ImdgBusProcess):
 
     def handle_close_response(self, packet: PDCloseRep) -> None:
         """PD_CLOSE_REP를 socket.io로 broadcast."""
+        self.broadcast_to_clients(packet)
+
+    def handle_stop_request(self, packet: PDStopReq) -> None:
+        from process_category.enum_category import E_CATE
+
+        sender = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
+        receiver = ProtocolOwner.build(E_CATE.STREAMER, E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER)
+
+        message = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.STOP_REQ)(
+            sender,
+            receiver,
+        )
+
+        envelope = ProtocolWrapper.get_protocol_wrapper(message).get_protocol_packet_message()
+        self.send_message_imdg(envelope)
+
+    def handle_stop_response(self, packet: PDStopRep) -> None:
+        """PD_STOP_REP를 socket.io로 broadcast."""
         self.broadcast_to_clients(packet)

--- a/src/app/streamer/process/manager/manager.py
+++ b/src/app/streamer/process/manager/manager.py
@@ -8,6 +8,7 @@ from protocol.message.imdg.close import CloseReq
 from protocol.message.imdg.pause import PauseReq
 from protocol.message.imdg.play import PlayReq
 from protocol.message.imdg.seek import SeekReq
+from protocol.message.imdg.stop import StopReq
 from protocol.message.message import IMessage
 
 from app.streamer.process.manager.state import (
@@ -201,6 +202,39 @@ class StreamerManager(ImdgBusProcess):
         else:
             self.send_message_rep_imdg(
                 E_PROTOCOL_ID.CLOSE_REP, bridge,
+                response=make_response_info(E_CODE.OK),
+            )
+
+        if self._state_component is not None:
+            self._state_component.change_state(E_STREAMER_MANAGER_STATE.WAIT)
+
+    def handle_stop_request(self, packet: StopReq) -> None:
+        # Stop은 어떤 state에서든 의미 있음(현재 활성 흐름 종료) — state 체크 생략하고 일단 STOP 진입.
+        if self._state_component is not None:
+            self._state_component.change_state(E_STREAMER_MANAGER_STATE.STOP, state_param_dto=packet)
+
+    def handle_stop_response(self, packet) -> None:
+        # 매처 경로(handle_stop_group_response)가 후처리 — 개별 handler는 no-op.
+        pass
+
+    def handle_stop_group_response(self, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+        from protocol.protocol_owner import ProtocolOwner
+
+        bridge = ProtocolOwner.build(
+            E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE
+        )
+
+        if pair_state == E_PROTOCOL_PAIR_STATE.ERROR:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.STOP_REP, bridge,
+                response=make_response_info(E_CODE.INVALID_REQUEST, "module error"),
+            )
+        else:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.STOP_REP, bridge,
                 response=make_response_info(E_CODE.OK),
             )
 

--- a/src/app/streamer/process/manager/state/__init__.py
+++ b/src/app/streamer/process/manager/state/__init__.py
@@ -5,6 +5,7 @@ from app.streamer.process.manager.state.pause import PauseState
 from app.streamer.process.manager.state.play import PlayState
 from app.streamer.process.manager.state.seek import SeekState
 from app.streamer.process.manager.state.state_enum import E_STREAMER_MANAGER_STATE
+from app.streamer.process.manager.state.stop import StopState
 from app.streamer.process.manager.state.wait import WaitState
 
 
@@ -16,5 +17,6 @@ def build_state_map() -> StateMap:
         E_STREAMER_MANAGER_STATE.PAUSE: PauseState(state_map, E_STREAMER_MANAGER_STATE.PAUSE),
         E_STREAMER_MANAGER_STATE.SEEK: SeekState(state_map, E_STREAMER_MANAGER_STATE.SEEK),
         E_STREAMER_MANAGER_STATE.CLOSE: CloseState(state_map, E_STREAMER_MANAGER_STATE.CLOSE),
+        E_STREAMER_MANAGER_STATE.STOP: StopState(state_map, E_STREAMER_MANAGER_STATE.STOP),
     }
     return state_map

--- a/src/app/streamer/process/manager/state/state_enum.py
+++ b/src/app/streamer/process/manager/state/state_enum.py
@@ -7,3 +7,4 @@ class E_STREAMER_MANAGER_STATE(IntEnum):
     PAUSE = 2
     SEEK = 3
     CLOSE = 4
+    STOP = 5

--- a/src/app/streamer/process/manager/state/stop.py
+++ b/src/app/streamer/process/manager/state/stop.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_library.state import abState
+
+from protocol.message.imdg.stop import StopReq
+
+if TYPE_CHECKING:
+    from app.streamer.process.manager.manager import StreamerManager
+
+
+class StopState(abState):
+    owner: StreamerManager
+
+    def on_enter(self):
+        assert isinstance(self.state_param_dto, StopReq)
+
+    def on_leave(self): pass
+
+    def on_proc_once(self):
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        # 활성 sensor module list 추적은 후속 작업 — placeholder는 빈 리스트.
+        receivers: list[str] = []
+
+        self.owner.broadcast_message_req_inner_queue(
+            E_PROTOCOL_ID.INR_STOP_REQ,
+            receivers,
+            rep_protocol_id=E_PROTOCOL_ID.INR_STOP_REP,
+        )
+
+    def on_proc_every_frame(self): pass

--- a/src/app/streamer/process/module/module.py
+++ b/src/app/streamer/process/module/module.py
@@ -7,6 +7,7 @@ from protocol.message.process.close import InrCloseReq
 from protocol.message.process.pause import InrPauseReq
 from protocol.message.process.play import InrPlayReq
 from protocol.message.process.seek import InrSeekReq
+from protocol.message.process.stop import InrStopReq
 
 from app.streamer.process.module.state import (
     E_STREAMER_MODULE_STATE,
@@ -78,5 +79,13 @@ class StreamerModule(QueueControlProcess):
         if self._state_component is not None:
             self._state_component.change_state(
                 E_STREAMER_MODULE_STATE.CLOSE,
+                state_param_dto=packet,
+            )
+
+    def handle_stop_request(self, packet: InrStopReq) -> None:
+        # placeholder — 실제 GStreamer stop 흐름 미이식. 어떤 state든 일단 STOP 진입 후 즉시 OK.
+        if self._state_component is not None:
+            self._state_component.change_state(
+                E_STREAMER_MODULE_STATE.STOP,
                 state_param_dto=packet,
             )

--- a/src/app/streamer/process/module/state/__init__.py
+++ b/src/app/streamer/process/module/state/__init__.py
@@ -5,6 +5,7 @@ from app.streamer.process.module.state.pause import PauseState
 from app.streamer.process.module.state.play import PlayState
 from app.streamer.process.module.state.seek import SeekState
 from app.streamer.process.module.state.state_enum import E_STREAMER_MODULE_STATE
+from app.streamer.process.module.state.stop import StopState
 from app.streamer.process.module.state.wait import WaitState
 
 
@@ -16,5 +17,6 @@ def build_state_map() -> StateMap:
         E_STREAMER_MODULE_STATE.PAUSE: PauseState(state_map, E_STREAMER_MODULE_STATE.PAUSE),
         E_STREAMER_MODULE_STATE.SEEK: SeekState(state_map, E_STREAMER_MODULE_STATE.SEEK),
         E_STREAMER_MODULE_STATE.CLOSE: CloseState(state_map, E_STREAMER_MODULE_STATE.CLOSE),
+        E_STREAMER_MODULE_STATE.STOP: StopState(state_map, E_STREAMER_MODULE_STATE.STOP),
     }
     return state_map

--- a/src/app/streamer/process/module/state/state_enum.py
+++ b/src/app/streamer/process/module/state/state_enum.py
@@ -7,3 +7,4 @@ class E_STREAMER_MODULE_STATE(IntEnum):
     PAUSE = 2
     SEEK = 3
     CLOSE = 4
+    STOP = 5

--- a/src/app/streamer/process/module/state/stop.py
+++ b/src/app/streamer/process/module/state/stop.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_library.state import abState
+
+from protocol.message.process.stop import InrStopReq
+
+if TYPE_CHECKING:
+    from app.streamer.process.module.module import StreamerModule
+
+
+class StopState(abState):
+    """Pcaps/GStreamer 미이식 상태의 placeholder — 진입 즉시 OK 응답 후 WAIT 복귀."""
+    owner: StreamerModule
+
+    def on_enter(self):
+        assert isinstance(self.state_param_dto, InrStopReq)
+
+    def on_leave(self): pass
+
+    def on_proc_once(self):
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        self.owner.send_message_rep_inner_queue(
+            E_PROTOCOL_ID.INR_STOP_REP,
+            E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER,
+            response=make_response_info(E_CODE.OK),
+        )
+
+        from app.streamer.process.module.state.state_enum import E_STREAMER_MODULE_STATE
+        self.owner._state_component.change_state(E_STREAMER_MODULE_STATE.WAIT)
+
+    def on_proc_every_frame(self): pass

--- a/src/protocol/message/external/ui/stop.py
+++ b/src/protocol/message/external/ui/stop.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from protocol.message.external.external import pdPacket, pdResponsePacket
+
+
+@dataclass
+class PDStopReq(pdPacket):
+    pass
+
+
+@dataclass
+class PDStopRep(pdResponsePacket):
+    pass

--- a/src/protocol/message/imdg/stop.py
+++ b/src/protocol/message/imdg/stop.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from protocol.message.imdg.imdg import abImdgRequestMessage, abImdgResponseMessage
+
+
+@dataclass
+class StopReq(abImdgRequestMessage):
+    pass
+
+
+@dataclass
+class StopRep(abImdgResponseMessage):
+    pass

--- a/src/protocol/message/process/stop.py
+++ b/src/protocol/message/process/stop.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from protocol.message.process.process import abProcessRequestMessage, abProcessResponseMessage
+
+
+@dataclass
+class InrStopReq(abProcessRequestMessage):
+    pass
+
+
+@dataclass
+class InrStopRep(abProcessResponseMessage):
+    pass

--- a/src/protocol/protocol_handler.py
+++ b/src/protocol/protocol_handler.py
@@ -14,17 +14,20 @@ from protocol.message.external.ui.pause import PDPauseReq, PDPauseRep
 from protocol.message.external.ui.play import PDPlayReq, PDPlayRep
 from protocol.message.external.ui.playable_list import PDPlayableListReq, PDPlayableListRep
 from protocol.message.external.ui.seek import PDSeekReq, PDSeekRep
+from protocol.message.external.ui.stop import PDStopReq, PDStopRep
 from protocol.message.imdg.close import CloseReq, CloseRep
 from protocol.message.imdg.pause import PauseReq, PauseRep
 from protocol.message.imdg.play import PlayReq, PlayRep
 from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
 from protocol.message.imdg.seek import SeekReq, SeekRep
+from protocol.message.imdg.stop import StopReq, StopRep
 from protocol.message.message import IMessage
 from protocol.message.process.close import InrCloseReq, InrCloseRep
 from protocol.message.process.pause import InrPauseReq, InrPauseRep
 from protocol.message.process.play import InrPlayReq, InrPlayRep
 from protocol.message.process.playable_list import InrPlayableListReq, InrPlayableListRep
 from protocol.message.process.seek import InrSeekReq, InrSeekRep
+from protocol.message.process.stop import InrStopReq, InrStopRep
 from protocol.protocol_wrapper import ProtocolWrapper
 
 
@@ -82,6 +85,16 @@ class ProtocolHandler:
         assert isinstance(packet, PDCloseRep)
         process.handle_close_response(packet)
 
+    @staticmethod
+    def pd_stop_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PDStopReq)
+        process.handle_stop_request(packet)
+
+    @staticmethod
+    def pd_stop_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, PDStopRep)
+        process.handle_stop_response(packet)
+
     # ---------------------------
     # IMDG — 앱 간 통신
     # ---------------------------
@@ -134,6 +147,16 @@ class ProtocolHandler:
     def close_response(process, wrapper: ProtocolWrapper, packet: IMessage):
         assert isinstance(packet, CloseRep)
         process.handle_close_response(packet)
+
+    @staticmethod
+    def stop_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, StopReq)
+        process.handle_stop_request(packet)
+
+    @staticmethod
+    def stop_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, StopRep)
+        process.handle_stop_response(packet)
 
     # ---------------------------
     # PROCESS (INR) — 앱 내 통신
@@ -188,6 +211,16 @@ class ProtocolHandler:
         assert isinstance(packet, InrCloseRep)
         process.handle_close_response(packet)
 
+    @staticmethod
+    def inr_stop_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, InrStopReq)
+        process.handle_stop_request(packet)
+
+    @staticmethod
+    def inr_stop_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(packet, InrStopRep)
+        process.handle_stop_response(packet)
+
     # ---------------------------
     # Group dispatchers — 시그니처 다름 (process, pair_state, packets)
     # ---------------------------
@@ -210,3 +243,7 @@ class ProtocolHandler:
     @staticmethod
     def inr_close_response_group(process, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]):
         process.handle_close_group_response(pair_state, packets)
+
+    @staticmethod
+    def inr_stop_response_group(process, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]):
+        process.handle_stop_group_response(pair_state, packets)

--- a/src/protocol/protocol_meta.py
+++ b/src/protocol/protocol_meta.py
@@ -53,6 +53,13 @@ class E_PROTOCOL_ID(Enum):
     INR_CLOSE_REQ = "-300"
     INR_CLOSE_REP = "-301"
 
+    PD_STOP_REQ = "PD_600"
+    PD_STOP_REP = "PD_601"
+    STOP_REQ = "600"
+    STOP_REP = "601"
+    INR_STOP_REQ = "-600"
+    INR_STOP_REP = "-601"
+
 
 @dataclass(frozen=True)
 class ProtocolEntry:
@@ -102,16 +109,19 @@ class ProtocolMeta:
         from protocol.message.external.ui.play import PDPlayReq, PDPlayRep
         from protocol.message.external.ui.playable_list import PDPlayableListReq, PDPlayableListRep
         from protocol.message.external.ui.seek import PDSeekReq, PDSeekRep
+        from protocol.message.external.ui.stop import PDStopReq, PDStopRep
         from protocol.message.imdg.close import CloseReq, CloseRep
         from protocol.message.imdg.pause import PauseReq, PauseRep
         from protocol.message.imdg.play import PlayReq, PlayRep
         from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
         from protocol.message.imdg.seek import SeekReq, SeekRep
+        from protocol.message.imdg.stop import StopReq, StopRep
         from protocol.message.process.close import InrCloseReq, InrCloseRep
         from protocol.message.process.pause import InrPauseReq, InrPauseRep
         from protocol.message.process.play import InrPlayReq, InrPlayRep
         from protocol.message.process.playable_list import InrPlayableListReq, InrPlayableListRep
         from protocol.message.process.seek import InrSeekReq, InrSeekRep
+        from protocol.message.process.stop import InrStopReq, InrStopRep
         from protocol.protocol_handler import ProtocolHandler
 
         # ===== PlayableList 3계층 =====
@@ -691,6 +701,116 @@ class ProtocolMeta:
                 },
                 inr_group_receive_handlers={
                     E_CATE.STREAMER: ProtocolHandler.inr_close_response_group,
+                },
+            ),
+        )
+
+        # ===== Stop 3계층 =====
+
+        # PD_STOP_REQ → REST_SERVER
+        cls._register(
+            E_PROTOCOL_ID.PD_STOP_REQ,
+            ProtocolEntry(
+                factory=lambda sender, receiver: PDStopReq(
+                    protocol_id=E_PROTOCOL_ID.PD_STOP_REQ.value,
+                    sender=sender,
+                    receiver=receiver,
+                ),
+                decoder=PDStopReq.from_json,
+                receive_handlers={
+                    E_CATE.REST_SERVER: ProtocolHandler.pd_stop_request,
+                },
+            ),
+        )
+
+        # PD_STOP_REP → REST_SERVER (socket.io broadcast)
+        cls._register(
+            E_PROTOCOL_ID.PD_STOP_REP,
+            ProtocolEntry(
+                factory=lambda sender, receiver, code, code_nm, reason: PDStopRep(
+                    protocol_id=E_PROTOCOL_ID.PD_STOP_REP.value,
+                    sender=sender,
+                    receiver=receiver,
+                    code=code,
+                    code_nm=code_nm,
+                    reason=reason,
+                ),
+                decoder=PDStopRep.from_json,
+                receive_handlers={
+                    E_CATE.REST_SERVER: ProtocolHandler.pd_stop_response,
+                },
+            ),
+        )
+
+        # STOP_REQ → BRIDGE / STREAMER / DOWNLOADER
+        cls._register(
+            E_PROTOCOL_ID.STOP_REQ,
+            ProtocolEntry(
+                factory=lambda sender, receiver: StopReq(
+                    protocol_id=E_PROTOCOL_ID.STOP_REQ.value,
+                    sender=sender,
+                    receiver=receiver,
+                ),
+                decoder=StopReq.from_json,
+                receive_handlers={
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.stop_request,
+                    E_CATE.STREAMER: ProtocolHandler.stop_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.stop_request,
+                },
+            ),
+        )
+
+        # STOP_REP → MESSAGE_BRIDGE
+        cls._register(
+            E_PROTOCOL_ID.STOP_REP,
+            ProtocolEntry(
+                factory=lambda sender, receiver, response=None: StopRep(
+                    protocol_id=E_PROTOCOL_ID.STOP_REP.value,
+                    sender=sender,
+                    receiver=receiver,
+                    response=response,
+                ),
+                decoder=StopRep.from_json,
+                receive_handlers={
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.stop_response,
+                },
+            ),
+        )
+
+        # INR_STOP_REQ → STREAMER (Module) / DOWNLOADER (Module)
+        cls._register(
+            E_PROTOCOL_ID.INR_STOP_REQ,
+            ProtocolEntry(
+                factory=lambda sender, receiver: InrStopReq(
+                    protocol_id=E_PROTOCOL_ID.INR_STOP_REQ.value,
+                    sender=sender,
+                    receiver=receiver,
+                ),
+                decoder=InrStopReq.from_json,
+                receive_handlers={
+                    E_CATE.STREAMER: ProtocolHandler.inr_stop_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_stop_request,
+                },
+            ),
+        )
+
+        # INR_STOP_REP → STREAMER (Manager) / DOWNLOADER (Manager) + group
+        cls._register(
+            E_PROTOCOL_ID.INR_STOP_REP,
+            ProtocolEntry(
+                factory=lambda sender, receiver, response=None: InrStopRep(
+                    protocol_id=E_PROTOCOL_ID.INR_STOP_REP.value,
+                    sender=sender,
+                    receiver=receiver,
+                    response=response,
+                ),
+                decoder=InrStopRep.from_json,
+                receive_handlers={
+                    E_CATE.STREAMER: ProtocolHandler.inr_stop_response,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_stop_response,
+                },
+                inr_group_receive_handlers={
+                    E_CATE.STREAMER: ProtocolHandler.inr_stop_response_group,
                 },
             ),
         )


### PR DESCRIPTION
## Summary
- **Stop 패킷 3계층**: PD_STOP_REQ/REP(PD_600/601), STOP_REQ/REP(600/601), INR_STOP_REQ/REP(-600/-601) 6종 메시지 dataclass + ProtocolEntry 등록. Pause/Close와 동일하게 sender/receiver만 — 추가 필드 없음
- **ProtocolHandler dispatcher 7개 추가**: 6 normal + 1 group(inr_stop_response_group). 라우팅은 일관 — STOP_REQ는 BRIDGE+STREAMER+DOWNLOADER broadcast
- **STREAMER STOP state 신설**: Manager/Module 양쪽 5 → 6 state(WAIT/PLAY/PAUSE/SEEK/CLOSE/STOP). `StreamerManager.handle_stop_request`은 state 체크 없이 무조건 STOP 진입(Close와 동일하게 종료 명령은 어느 시점에도 의미 있음)
- **handler 본체**: SocketIOProcess(PD↔IMDG), MessageBridgeProcess(STOP_REP→PD_STOP_REP). DOWNLOADER 쪽은 NotImplementedError stub 유지
- **Play lifecycle 5종 라우팅 마무리**: PlayableList(#46) → Play(#58) → Pause(#62) → Seek(#64) → Close(#66) → Stop(#68) 패킷 추가 완료. 후속 작업은 Pcaps 모듈 이식 / Download 흐름 본체 / ProtocolEntry 단순화

## Related Issues
- close #68