### PR TITLE
[feat] #74 StreamerModule Pcaps 통합 Phase 1 — PlayState PCAP 파일 read

### DIFF
--- a/src/app/streamer/process/module/module.py
+++ b/src/app/streamer/process/module/module.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from typing import Optional
 
+from python_library.storage.local.local_storage_factory import LocalStorageFactory
+from python_library.storage.local.local_storage_info_factory import LocalStorageInfoFactory
+from python_library.storage.storage import IStorage
+
 from common.process.queue_control_process import QueueControlProcess
+from config.project_config import ProjectConfig
 from protocol.message.process.close import InrCloseReq
 from protocol.message.process.pause import InrPauseReq
 from protocol.message.process.play import InrPlayReq
@@ -18,13 +23,31 @@ from app.streamer.process.module.state import (
 class StreamerModule(QueueControlProcess):
     def __init__(self, app_name, process_name):
         super().__init__(app_name, process_name)
+        self._storage: Optional[IStorage] = None
+        self._storage_root: str = ""
+        self._storage_prefix: str = ""
 
     def on_init(self):
         super().on_init()
+        config = ProjectConfig.instance()
+        self._storage_root = (config.storage_root or "").rstrip("/")
+        self._storage_prefix = (config.storage_prefix or "").strip("/")
+        self._storage = LocalStorageFactory(LocalStorageInfoFactory()).create_storage()
+        self._storage.connect()
+
         self.set_state_component(
             build_state_map(),
             E_STREAMER_MODULE_STATE.WAIT,
         )
+
+    def get_storage(self) -> Optional[IStorage]:
+        return self._storage
+
+    def get_storage_root(self) -> str:
+        return self._storage_root
+
+    def get_storage_prefix(self) -> str:
+        return self._storage_prefix
 
     def get_current_state_id(self) -> Optional[E_STREAMER_MODULE_STATE]:
         if self._state_component is None:

--- a/src/app/streamer/process/module/state/helper/pcap_player.py
+++ b/src/app/streamer/process/module/state/helper/pcap_player.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+from typing import Optional
+
+from pcaps.packet import PcapPacket
+from pcaps.pool import PcapPool
+from pcaps.reader.multi import MultiPcapReader
+from sensor_category.sensor_category import SensorCategory
+
+_TIMESTAMP_FORMAT = "%Y%m%d%H%M%S"
+_DATE_FORMAT = "%Y%m%d"
+_HOUR_FORMAT = "%H"
+_MINUTE_FORMAT = "%M"
+
+
+class PcapPlayer:
+    """sensor 1개에 대한 1초 단위 PCAP 파일 read 흐름.
+
+    storage path 구성:
+        {storage_root}/{storage_prefix}/{vehicle}/{category}/{sensor_lower}/
+            {YYYYMMDD}/{HH}/{MM}/{sensor_lower}_{YYYYMMDDHH24MISS}.pcap
+
+    sender thread 통합은 Phase 2 — 본 helper는 read만 담당.
+    """
+
+    def __init__(
+        self,
+        storage_root: str,
+        storage_prefix: str,
+        vehicle_id: str,
+        sensor_id: str,
+        start_time: str,
+        end_time: str,
+    ) -> None:
+        self._storage_root = storage_root
+        self._storage_prefix = storage_prefix
+        self._vehicle_id = vehicle_id
+        self._sensor_id = sensor_id
+        self._start_time = start_time
+        self._end_time = end_time
+
+        self._pool: PcapPool = PcapPool()
+        self._error: Optional[Exception] = None
+
+    def read(self) -> bool:
+        """1초 단위로 PCAP 파일을 순차 read하여 PcapPool에 누적. 성공 True."""
+        try:
+            category = SensorCategory.get(self._sensor_id)
+            if category is None:
+                self._error = ValueError(f"unknown sensor: {self._sensor_id}")
+                return False
+
+            multi_reader = MultiPcapReader()
+            start_dt = datetime.strptime(self._start_time, _TIMESTAMP_FORMAT)
+            end_dt = datetime.strptime(self._end_time, _TIMESTAMP_FORMAT)
+
+            cursor = start_dt
+            while cursor < end_dt:
+                file_path = self._build_pcap_path(category, cursor)
+                if not os.path.isfile(file_path):
+                    self._error = FileNotFoundError(file_path)
+                    return False
+
+                reader = multi_reader.read(file_path)
+                for packet in reader.pool.packets:
+                    self._pool.append(packet)
+
+                cursor += timedelta(seconds=1)
+
+            return True
+        except Exception as exc:
+            self._error = exc
+            return False
+
+    @property
+    def pool(self) -> PcapPool:
+        return self._pool
+
+    @property
+    def error(self) -> Optional[Exception]:
+        return self._error
+
+    @property
+    def packet_count(self) -> int:
+        return self._pool.size
+
+    def _build_pcap_path(self, category: str, when: datetime) -> str:
+        sensor_lower = self._sensor_id.lower()
+        timestamp = when.strftime(_TIMESTAMP_FORMAT)
+        parts = [
+            self._storage_root,
+            self._storage_prefix,
+            self._vehicle_id,
+            category,
+            sensor_lower,
+            when.strftime(_DATE_FORMAT),
+            when.strftime(_HOUR_FORMAT),
+            when.strftime(_MINUTE_FORMAT),
+            f"{sensor_lower}_{timestamp}.pcap",
+        ]
+        joined = "/".join(p for p in parts if p)
+        return os.path.normpath(joined)

--- a/src/app/streamer/process/module/state/play.py
+++ b/src/app/streamer/process/module/state/play.py
@@ -6,12 +6,17 @@ from python_library.state import abState
 
 from protocol.message.process.play import InrPlayReq
 
+from app.streamer.process.module.state.helper.pcap_player import PcapPlayer
+
 if TYPE_CHECKING:
     from app.streamer.process.module.module import StreamerModule
 
 
 class PlayState(abState):
-    """Pcaps/GStreamer 미이식 상태의 placeholder — 진입 즉시 OK 응답 후 WAIT 복귀."""
+    """sensor 1개에 대한 PCAP 파일 read 흐름.
+
+    Phase 1: read 완료 시 OK 응답 + WAIT 복귀. 실제 패킷 송출은 Phase 2.
+    """
     owner: StreamerModule
 
     def on_enter(self):
@@ -24,15 +29,44 @@ class PlayState(abState):
         from protocol.protocol_code import E_CODE, make_response_info
         from protocol.protocol_meta import E_PROTOCOL_ID
 
+        assert isinstance(self.state_param_dto, InrPlayReq)
         sensor_id = self.owner.name
 
+        player = PcapPlayer(
+            storage_root=self.owner.get_storage_root(),
+            storage_prefix=self.owner.get_storage_prefix(),
+            vehicle_id=self.state_param_dto.vehicle_id,
+            sensor_id=sensor_id,
+            start_time=self.state_param_dto.start_time,
+            end_time=self.state_param_dto.end_time,
+        )
+
+        if not player.read():
+            self.__send_invalid_request(str(player.error))
+            self.__transition_to_wait()
+            return
+
+        # TODO Phase 2: PcapSenderThread로 player.pool 송출
         self.owner.send_message_rep_inner_queue(
             E_PROTOCOL_ID.INR_PLAY_REP,
             E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER,
             response=make_response_info(E_CODE.OK),
         )
-
-        from app.streamer.process.module.state.state_enum import E_STREAMER_MODULE_STATE
-        self.owner._state_component.change_state(E_STREAMER_MODULE_STATE.WAIT)
+        self.__transition_to_wait()
 
     def on_proc_every_frame(self): pass
+
+    def __send_invalid_request(self, reason: str) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        self.owner.send_message_rep_inner_queue(
+            E_PROTOCOL_ID.INR_PLAY_REP,
+            E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER,
+            response=make_response_info(E_CODE.INVALID_REQUEST, reason=reason),
+        )
+
+    def __transition_to_wait(self) -> None:
+        from app.streamer.process.module.state.state_enum import E_STREAMER_MODULE_STATE
+        self.owner._state_component.change_state(E_STREAMER_MODULE_STATE.WAIT)


### PR DESCRIPTION
## Summary
- **PcapPlayer helper 신설**: sensor 1개에 대한 1초 단위 PCAP 파일 read. `{storage_root}/{prefix}/{vehicle}/{category}/{sensor_lower}/YMD/HH/MM/{sensor_lower}_{YYYYMMDDHH24MISS}.pcap` 경로에서 MultiPcapReader로 파일별 read → 자기 PcapPool에 누적. SensorCategory.get으로 category(lidar/gnss/camera) 자동 결정
- **StreamerModule storage 의존성**: DownloaderModule.on_init 패턴 미러 — LocalStorageFactory + storage_root/storage_prefix + get_storage 등 accessor
- **PlayState placeholder 제거**: 즉시 OK 응답하던 placeholder를 PcapPlayer.read() 호출로 교체. 성공 시 INR_PLAY_REP OK, 실패 시 INVALID_REQUEST + reason. 어느 경우든 WAIT 복귀
- **검증**: import 무결성, FileNotFoundError 처리, unknown sensor ValueError 처리, 임시 디렉토리에 위조 PCAP 만들어 read 성공 확인 (1 패킷 누적)
- **Phase 2/3 범위**: PcapSenderThread로 pool의 패킷을 시간 offset에 맞춰 UDP 송출(Phase 2), Pause/Seek/Close/Stop 본체 동작(Phase 3)

## Related Issues
- close #74