### PR TITLE
[feat] #78 Pause/Seek/Close/Stop 라이프사이클 본체 동작 (Phase 3) — Play lifecycle 5종 완성

### DIFF
--- a/src/app/streamer/process/module/module.py
+++ b/src/app/streamer/process/module/module.py
@@ -18,6 +18,7 @@ from app.streamer.process.module.state import (
     E_STREAMER_MODULE_STATE,
     build_state_map,
 )
+from app.streamer.process.module.state.helper.pcap_player import PcapPlayer
 
 
 class StreamerModule(QueueControlProcess):
@@ -26,6 +27,13 @@ class StreamerModule(QueueControlProcess):
         self._storage: Optional[IStorage] = None
         self._storage_root: str = ""
         self._storage_prefix: str = ""
+        self._player: Optional[PcapPlayer] = None
+
+    def get_player(self) -> Optional[PcapPlayer]:
+        return self._player
+
+    def set_player(self, player: Optional[PcapPlayer]) -> None:
+        self._player = player
 
     def on_init(self):
         super().on_init()

--- a/src/app/streamer/process/module/state/close.py
+++ b/src/app/streamer/process/module/state/close.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class CloseState(abState):
-    """Pcaps/GStreamer 미이식 상태의 placeholder — 진입 즉시 OK 응답 후 WAIT 복귀."""
+    """player 종료 + None reset. replayer 미러 — stop과 동일 동작."""
     owner: StreamerModule
 
     def on_enter(self):
@@ -23,6 +23,14 @@ class CloseState(abState):
         from process_category.enum_category import E_CATE
         from protocol.protocol_code import E_CODE, make_response_info
         from protocol.protocol_meta import E_PROTOCOL_ID
+
+        player = self.owner.get_player()
+        if player is not None:
+            try:
+                player.close()
+            except Exception:
+                pass
+            self.owner.set_player(None)
 
         self.owner.send_message_rep_inner_queue(
             E_PROTOCOL_ID.INR_CLOSE_REP,

--- a/src/app/streamer/process/module/state/helper/pcap_player.py
+++ b/src/app/streamer/process/module/state/helper/pcap_player.py
@@ -18,10 +18,11 @@ class PcapPlayer:
     구조:
         PcapReaderThread (producer) → PcapPool (buffer) → PcapSenderThread (consumer)
 
-    외부 API:
+    라이프사이클:
         start() — 두 thread 시작
-        stop()  — 두 thread 종료
-        on_ready / on_complete / on_error callback으로 외부 통보
+        pause() / resume() — sender 송출 일시정지/재개 (reader는 영향 없음)
+        seek(start, end) — reader 교체 + pool clear + 재시작 (sender는 그대로)
+        stop() / close() — reader/sender 모두 join (replayer 미러 — 동일 동작)
     """
 
     def __init__(
@@ -42,24 +43,21 @@ class PcapPlayer:
         on_complete: Optional[CompleteCallback] = None,
         on_error: Optional[ErrorCallback] = None,
     ) -> None:
+        self._storage_root = storage_root
+        self._storage_prefix = storage_prefix
+        self._vehicle_id = vehicle_id
+        self._sensor_id = sensor_id
+        self._ready_threshold_seconds = ready_threshold_seconds
+        self._file_refind_count = file_refind_count
+        self._file_refind_sleep_time = file_refind_sleep_time
+        self._on_ready = on_ready
+        self._on_complete = on_complete
+        self._on_error = on_error
+        self._end_time = end_time   # seek 시 새 start_time과 결합
+
         self._pool: PcapPool = PcapPool(max_size=buffer_size)
-
-        self._reader = PcapReaderThread(
-            pool=self._pool,
-            storage_root=storage_root,
-            storage_prefix=storage_prefix,
-            vehicle_id=vehicle_id,
-            sensor_id=sensor_id,
-            start_time=start_time,
-            end_time=end_time,
-            ready_threshold_seconds=ready_threshold_seconds,
-            file_refind_count=file_refind_count,
-            file_refind_sleep_time=file_refind_sleep_time,
-            on_ready=on_ready,
-            on_error=on_error,
-        )
-
-        self._sender = PcapSenderThread(
+        self._reader: PcapReaderThread = self._make_reader(start_time, end_time)
+        self._sender: PcapSenderThread = PcapSenderThread(
             pool=self._pool,
             target_ip=target_ip,
             target_port=target_port,
@@ -67,13 +65,55 @@ class PcapPlayer:
             on_error=on_error,
         )
 
+    def _make_reader(self, start_time: str, end_time: str) -> PcapReaderThread:
+        return PcapReaderThread(
+            pool=self._pool,
+            storage_root=self._storage_root,
+            storage_prefix=self._storage_prefix,
+            vehicle_id=self._vehicle_id,
+            sensor_id=self._sensor_id,
+            start_time=start_time,
+            end_time=end_time,
+            ready_threshold_seconds=self._ready_threshold_seconds,
+            file_refind_count=self._file_refind_count,
+            file_refind_sleep_time=self._file_refind_sleep_time,
+            on_ready=self._on_ready,
+            on_error=self._on_error,
+        )
+
     def start(self) -> None:
         self._reader.start()
         self._sender.start()
 
+    def pause(self) -> None:
+        """송출 일시정지. reader는 계속 buffer 채움."""
+        self._sender.pause()
+
+    def resume(self) -> None:
+        self._sender.resume()
+
+    def seek(self, start_time: str) -> None:
+        """reader cursor 재설정 — 기존 reader stop + pool clear + 새 reader start.
+
+        end_time은 init 시점 값 유지. sender는 pause 중이면 resume 포함.
+        """
+        self._reader.stop()
+        self._reader.join()
+        self._pool.clear()
+        self._reader = self._make_reader(start_time, self._end_time)
+        self._reader.start()
+        self._sender.resume()
+
     def stop(self) -> None:
+        """reader/sender 모두 종료 + join."""
         self._reader.stop()
         self._sender.stop()
+        self._reader.join()
+        self._sender.join()
+
+    def close(self) -> None:
+        """replayer 미러 — stop과 동일 동작."""
+        self.stop()
 
     def join(self) -> None:
         self._reader.join()
@@ -82,3 +122,7 @@ class PcapPlayer:
     @property
     def pool(self) -> PcapPool:
         return self._pool
+
+    @property
+    def is_paused(self) -> bool:
+        return self._sender.is_pause()

--- a/src/app/streamer/process/module/state/helper/pcap_sender_thread.py
+++ b/src/app/streamer/process/module/state/helper/pcap_sender_thread.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import socket
+import threading
 import time
 from typing import Callable, Optional
 
@@ -15,6 +16,7 @@ ErrorCallback = Callable[[Exception], None]
 class PcapSenderThread(abThread):
     """PcapPool에서 패킷 꺼내 time.offset_time 만큼 sleep 후 UDP 송출 consumer thread.
 
+    pause_event 세팅 시 송출 일시정지 (Pool은 그대로 둠 — reader 계속 채울 수 있음).
     replayer App/Streamer/GStreamer/State/Helper/PcapSenderThread.py 미러.
     """
 
@@ -33,6 +35,17 @@ class PcapSenderThread(abThread):
         self._on_complete = on_complete
         self._on_error = on_error
         self._socket: Optional[socket.socket] = None
+        self._pause_event = threading.Event()
+
+    def pause(self) -> None:
+        """송출 일시정지 — pop_front 직전에 대기. reader는 영향 없음."""
+        self._pause_event.set()
+
+    def resume(self) -> None:
+        self._pause_event.clear()
+
+    def is_pause(self) -> bool:
+        return self._pause_event.is_set()
 
     def action(self) -> None:
         try:
@@ -50,6 +63,11 @@ class PcapSenderThread(abThread):
         max_empty_before_complete = 100  # 1초 (10ms * 100) empty면 EOF로 간주
 
         while not self.is_stop():
+            # pause 중이면 짧게 sleep 후 재확인
+            if self.is_pause():
+                time.sleep(0.01)
+                continue
+
             packet = self._pool.pop_front()
             if packet is None:
                 consecutive_empty += 1

--- a/src/app/streamer/process/module/state/pause.py
+++ b/src/app/streamer/process/module/state/pause.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class PauseState(abState):
-    """Pcaps/GStreamer 미이식 상태의 placeholder — 진입 즉시 OK 응답 후 WAIT 복귀."""
+    """sender 송출 일시정지 — reader는 계속 buffer 채움. player 유지."""
     owner: StreamerModule
 
     def on_enter(self):
@@ -24,13 +24,34 @@ class PauseState(abState):
         from protocol.protocol_code import E_CODE, make_response_info
         from protocol.protocol_meta import E_PROTOCOL_ID
 
+        player = self.owner.get_player()
+        if player is None:
+            self.__send_invalid_request("player not active")
+            self.__transition_to_wait()
+            return
+
+        player.pause()
+
         self.owner.send_message_rep_inner_queue(
             E_PROTOCOL_ID.INR_PAUSE_REP,
             E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER,
             response=make_response_info(E_CODE.OK),
         )
-
-        from app.streamer.process.module.state.state_enum import E_STREAMER_MODULE_STATE
-        self.owner._state_component.change_state(E_STREAMER_MODULE_STATE.WAIT)
+        self.__transition_to_wait()
 
     def on_proc_every_frame(self): pass
+
+    def __send_invalid_request(self, reason: str) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        self.owner.send_message_rep_inner_queue(
+            E_PROTOCOL_ID.INR_PAUSE_REP,
+            E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER,
+            response=make_response_info(E_CODE.INVALID_REQUEST, reason=reason),
+        )
+
+    def __transition_to_wait(self) -> None:
+        from app.streamer.process.module.state.state_enum import E_STREAMER_MODULE_STATE
+        self.owner._state_component.change_state(E_STREAMER_MODULE_STATE.WAIT)

--- a/src/app/streamer/process/module/state/play.py
+++ b/src/app/streamer/process/module/state/play.py
@@ -24,19 +24,16 @@ class PlayState(abState):
 
     def __init__(self, state_lists, state_id) -> None:
         super().__init__(state_lists, state_id)
-        self._player: Optional[PcapPlayer] = None
         self._ready_fired: bool = False
         self._error: Optional[Exception] = None
 
     def on_enter(self):
         assert isinstance(self.state_param_dto, InrPlayReq)
-        self._player = None
         self._ready_fired = False
         self._error = None
 
     def on_leave(self):
-        # PlayState 빠질 때 player는 그대로 유지 (Phase 3에서 Pause/Seek/Stop에 사용)
-        # 본 PR은 OK 응답 후 WAIT 복귀라 player가 background에서 계속 송출 + 자체 종료.
+        # player는 owner._player에 보존 — Pause/Seek/Close/Stop state에서 접근.
         pass
 
     def on_proc_once(self):
@@ -55,7 +52,7 @@ class PlayState(abState):
             self.__transition_to_wait()
             return
 
-        self._player = PcapPlayer(
+        player = PcapPlayer(
             storage_root=self.owner.get_storage_root(),
             storage_prefix=self.owner.get_storage_prefix(),
             vehicle_id=self.state_param_dto.vehicle_id,
@@ -71,7 +68,8 @@ class PlayState(abState):
             on_ready=self._on_ready,
             on_error=self._on_error,
         )
-        self._player.start()
+        self.owner.set_player(player)
+        player.start()
 
     def on_proc_every_frame(self):
         from process_category.enum_category import E_CATE

--- a/src/app/streamer/process/module/state/seek.py
+++ b/src/app/streamer/process/module/state/seek.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class SeekState(abState):
-    """Pcaps/GStreamer 미이식 상태의 placeholder — 진입 즉시 OK 응답 후 WAIT 복귀."""
+    """reader cursor 재설정 — pool clear + 새 reader 시작. player 유지."""
     owner: StreamerModule
 
     def on_enter(self):
@@ -24,13 +24,41 @@ class SeekState(abState):
         from protocol.protocol_code import E_CODE, make_response_info
         from protocol.protocol_meta import E_PROTOCOL_ID
 
+        assert isinstance(self.state_param_dto, InrSeekReq)
+
+        player = self.owner.get_player()
+        if player is None:
+            self.__send_invalid_request("player not active")
+            self.__transition_to_wait()
+            return
+
+        try:
+            player.seek(self.state_param_dto.start_time)
+        except Exception as exc:
+            self.__send_invalid_request(str(exc))
+            self.__transition_to_wait()
+            return
+
         self.owner.send_message_rep_inner_queue(
             E_PROTOCOL_ID.INR_SEEK_REP,
             E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER,
             response=make_response_info(E_CODE.OK),
         )
-
-        from app.streamer.process.module.state.state_enum import E_STREAMER_MODULE_STATE
-        self.owner._state_component.change_state(E_STREAMER_MODULE_STATE.WAIT)
+        self.__transition_to_wait()
 
     def on_proc_every_frame(self): pass
+
+    def __send_invalid_request(self, reason: str) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        self.owner.send_message_rep_inner_queue(
+            E_PROTOCOL_ID.INR_SEEK_REP,
+            E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER,
+            response=make_response_info(E_CODE.INVALID_REQUEST, reason=reason),
+        )
+
+    def __transition_to_wait(self) -> None:
+        from app.streamer.process.module.state.state_enum import E_STREAMER_MODULE_STATE
+        self.owner._state_component.change_state(E_STREAMER_MODULE_STATE.WAIT)

--- a/src/app/streamer/process/module/state/stop.py
+++ b/src/app/streamer/process/module/state/stop.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class StopState(abState):
-    """Pcaps/GStreamer 미이식 상태의 placeholder — 진입 즉시 OK 응답 후 WAIT 복귀."""
+    """player 종료 + None reset. Close와 동일 동작 (replayer 미러)."""
     owner: StreamerModule
 
     def on_enter(self):
@@ -23,6 +23,14 @@ class StopState(abState):
         from process_category.enum_category import E_CATE
         from protocol.protocol_code import E_CODE, make_response_info
         from protocol.protocol_meta import E_PROTOCOL_ID
+
+        player = self.owner.get_player()
+        if player is not None:
+            try:
+                player.stop()
+            except Exception:
+                pass
+            self.owner.set_player(None)
 
         self.owner.send_message_rep_inner_queue(
             E_PROTOCOL_ID.INR_STOP_REP,

--- a/src/pcaps/pool.py
+++ b/src/pcaps/pool.py
@@ -38,6 +38,11 @@ class PcapPool:
         with self._lock:
             return self._packets[0] if self._packets else None
 
+    def clear(self) -> None:
+        """Pool 비움 — seek 시 사용."""
+        with self._lock:
+            self._packets.clear()
+
     def get(self, index: int) -> PcapPacket:
         """index access — PcapReader.head_packet 등에서 사용."""
         with self._lock:


### PR DESCRIPTION
## Summary
- **PcapPlayer 라이프사이클 API 5종**: `pause()`/`resume()` (sender flag만 토글, reader 영향 없음), `seek(start_time)` (reader stop+join → pool clear → 새 reader 시작), `stop()`/`close()` (replayer 미러로 동일 동작)
- **PcapSenderThread.pause_event**: `threading.Event` 기반 송출 일시정지. send loop에서 `is_pause()` True면 sleep
- **StreamerModule._player**: process 단위로 player 보존. `get_player()`/`set_player()` accessor. PlayState가 `owner.set_player(player)`로 저장
- **4개 state 본체 구현** (placeholder 제거): PauseState→`player.pause()`, SeekState→`player.seek(start)`, CloseState/StopState→`player.close/stop()` + None reset
- **PcapPool.clear()** 추가 — seek 시 buffer 비우기
- **검증**: Pool clear + sender pause flag 토글 + E2E (10패킷 → pause → 0.2초 멈춤 확인 → resume → 총 10개 수신)
- **Play lifecycle 5종 완성**: Play/Pause/Seek/Close/Stop 모두 본체 동작

## Related Issues
- close #78