### PR TITLE
[test] #80 Pause/Seek/Close/Stop e2e 테스트 추가 — test_play.py 패턴 미러

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -21,3 +21,7 @@ sleep 2
 # 테스트 실행
 uv run pytest tests/test_client/test_playable_list.py -s
 uv run pytest tests/test_client/test_play.py -s
+uv run pytest tests/test_client/test_pause.py -s
+uv run pytest tests/test_client/test_seek.py -s
+uv run pytest tests/test_client/test_close.py -s
+uv run pytest tests/test_client/test_stop.py -s

--- a/tests/test_client/_lifecycle_helper.py
+++ b/tests/test_client/_lifecycle_helper.py
@@ -1,0 +1,156 @@
+"""Pause/Seek/Close/Stop e2e 테스트 공통 helper.
+
+test_play.py의 PlayableList → Play 시퀀스를 그대로 재사용하고, 그 위에서 한
+종류의 라이프사이클 명령(Pause/Seek/Close/Stop)을 송수신·검증한다.
+"""
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+import socketio
+
+_SERVER_URL = "http://localhost:9999"
+_CONNECT_TIMEOUT = 10
+_LIST_TIMEOUT = 15
+_PLAY_TIMEOUT = 15
+_LIFECYCLE_TIMEOUT = 15
+
+_PD_PLAYABLE_LIST_REQ = "PD_100"
+_PD_PLAYABLE_LIST_REP = "PD_101"
+_PD_PLAY_REQ = "PD_200"
+_PD_PLAY_REP = "PD_201"
+
+
+@dataclass
+class _SessionState:
+    list_rep: dict
+    play_rep: dict
+    lifecycle_rep: dict
+
+
+def _build_list_request(vehicle_id: str, sensors: list[str], start: str, end: str) -> dict:
+    return {
+        "protocol_id": _PD_PLAYABLE_LIST_REQ,
+        "message_direction": 0,
+        "sender": "UI",
+        "receiver": "REST_SERVER",
+        "vehicle_id": vehicle_id,
+        "sensor_id_list": sensors,
+        "start_time": start,
+        "end_time": end,
+    }
+
+
+def _build_play_request(section: dict, vehicle_id: str, sensors: list[str]) -> dict:
+    return {
+        "protocol_id": _PD_PLAY_REQ,
+        "message_direction": 0,
+        "sender": "UI",
+        "receiver": "REST_SERVER",
+        "section_id": section["sectionId"],
+        "vehicle_id": vehicle_id,
+        "sensor_id_list": sensors,
+        "start_time": section["startTime"],
+        "end_time": section["endTime"],
+    }
+
+
+def run_lifecycle_scenario(
+    *,
+    vehicle_id: str,
+    sensor_id_list: list[str],
+    start_time: str,
+    end_time: str,
+    lifecycle_req_id: str,
+    lifecycle_rep_id: str,
+    extra_payload: Optional[dict] = None,
+    on_section: Optional[Callable[[dict], None]] = None,
+) -> _SessionState:
+    """PlayableList → Play → 라이프사이클 한 종 시나리오를 실행하고 응답을 모은다.
+
+    extra_payload: 라이프사이클 요청에 합쳐질 추가 필드 (Seek의 start_time 등).
+    on_section: PlayableList 응답에서 chosen section을 받아 추가 검증 hook (필요 시).
+    """
+    sio = socketio.Client()
+    list_event = threading.Event()
+    play_event = threading.Event()
+    lifecycle_event = threading.Event()
+    state: dict[str, Optional[dict[str, Any]]] = {
+        "playable_list": None,
+        "play": None,
+        "lifecycle": None,
+    }
+
+    @sio.event
+    def connect():  # type: ignore[no-redef]
+        print("[client] connected")
+
+    @sio.event
+    def disconnect():  # type: ignore[no-redef]
+        print("[client] disconnected")
+
+    def on_message(data):
+        print(f"[client] recv: {data}")
+        parsed = json.loads(data) if isinstance(data, str) else data
+        pid = parsed.get("protocol_id")
+        if pid == _PD_PLAYABLE_LIST_REP:
+            state["playable_list"] = parsed
+            list_event.set()
+        elif pid == _PD_PLAY_REP:
+            state["play"] = parsed
+            play_event.set()
+        elif pid == lifecycle_rep_id:
+            state["lifecycle"] = parsed
+            lifecycle_event.set()
+
+    sio.on("message", on_message)
+    sio.connect(_SERVER_URL, wait_timeout=_CONNECT_TIMEOUT)
+
+    try:
+        list_req = _build_list_request(vehicle_id, sensor_id_list, start_time, end_time)
+        sio.emit("message", json.dumps(list_req))
+        print(f"[client] sent: {list_req}")
+        assert list_event.wait(timeout=_LIST_TIMEOUT), "PD_PLAYABLE_LIST_REP 응답을 시간 내 받지 못함"
+        list_rep = state["playable_list"]
+        assert list_rep is not None and list_rep["protocol_id"] == _PD_PLAYABLE_LIST_REP
+
+        sections = list_rep.get("section_list") or []
+        assert sections, "재생 가능한 section이 없음 — Play 단계 진행 불가"
+        chosen = sections[0]
+        print(f"[client] chosen section: {chosen}")
+        if on_section is not None:
+            on_section(chosen)
+
+        play_req = _build_play_request(chosen, vehicle_id, sensor_id_list)
+        sio.emit("message", json.dumps(play_req))
+        print(f"[client] sent: {play_req}")
+        assert play_event.wait(timeout=_PLAY_TIMEOUT), "PD_PLAY_REP 응답을 시간 내 받지 못함"
+        play_rep = state["play"]
+        assert play_rep is not None and play_rep["protocol_id"] == _PD_PLAY_REP
+
+        lifecycle_req = {
+            "protocol_id": lifecycle_req_id,
+            "message_direction": 0,
+            "sender": "UI",
+            "receiver": "REST_SERVER",
+        }
+        if extra_payload:
+            lifecycle_req.update(extra_payload)
+        sio.emit("message", json.dumps(lifecycle_req))
+        print(f"[client] sent: {lifecycle_req}")
+        assert lifecycle_event.wait(timeout=_LIFECYCLE_TIMEOUT), (
+            f"{lifecycle_rep_id} 응답을 시간 내 받지 못함"
+        )
+        lifecycle_rep = state["lifecycle"]
+        assert lifecycle_rep is not None
+    finally:
+        sio.disconnect()
+
+    return _SessionState(
+        list_rep=list_rep,
+        play_rep=play_rep,
+        lifecycle_rep=lifecycle_rep,
+    )

--- a/tests/test_client/conftest.py
+++ b/tests/test_client/conftest.py
@@ -1,0 +1,122 @@
+"""test_client e2e 테스트용 공통 fixture.
+
+- 4개 앱(REST_SERVER, MESSAGE_BRIDGE, DOWNLOADER, STREAMER) 실행 전제.
+- fake PCAP 파일을 임시 vehicle 경로에 생성 — playable_list lookup과 streamer
+  pcap reader 모두 만족하도록 ``{sensor_lower}_{timestamp}.pcap`` 규약 사용.
+"""
+from __future__ import annotations
+
+import shutil
+import struct
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from config.project_config import ProjectConfig  # noqa: E402
+from sensor_category.sensor_category import SensorCategory  # noqa: E402
+
+_TIMESTAMP_FORMAT = "%Y%m%d%H%M%S"
+
+# 테스트용 unique vehicle — 기존 seed(vehicle-001)와 격리.
+_TEST_VEHICLE_ID = "vehicle-test-lifecycle"
+_TEST_SENSORS = ["AT128_ROOF_FRONT", "GNSS"]
+_TEST_START = "20240101120000"
+# 4초 분량 — seek가 중간 시각으로 이동 가능하도록 여유.
+_TEST_END = "20240101120004"
+
+
+@dataclass(frozen=True)
+class FakePcapEnv:
+    vehicle_id: str
+    sensor_id_list: list[str]
+    start_time: str
+    end_time: str
+
+
+def _minimal_udp_ethernet_packet() -> bytes:
+    """Ethernet UDP 최소 패킷 — 42 byte payload (link 14 + IP 20 + UDP 8)."""
+    eth = bytes(12) + b"\x08\x00"           # dst+src MAC zeros, ethertype IPv4
+    ip = (
+        b"\x45\x00\x00\x1c"                  # ver/ihl, dscp, total_len=28
+        b"\x00\x00\x00\x00"                  # id, flags+offset
+        b"\x40\x11\x00\x00"                  # ttl=64, protocol=17 (UDP), checksum=0
+        b"\x7f\x00\x00\x01"                  # src=127.0.0.1
+        b"\x7f\x00\x00\x01"                  # dst=127.0.0.1
+    )
+    udp = b"\x04\xd2\x04\xd2\x00\x08\x00\x00"  # src=dst=1234, len=8, checksum=0
+    return eth + ip + udp
+
+
+def _write_minimal_pcap(path: Path, when: datetime) -> None:
+    """PCAP 1 packet — file header(24) + packet header(16) + body(42)."""
+    body = _minimal_udp_ethernet_packet()
+    file_header = struct.pack(
+        "<IHHIIII",
+        0xA1B2C3D4,          # magic
+        2, 4,                # major, minor
+        0, 0,                # gmt_to_local, timestamp(unused)
+        65535,               # max_caplen
+        1,                   # link_type = Ethernet
+    )
+    packet_header = struct.pack(
+        "<IIII",
+        int(when.timestamp()),
+        0,                   # microseconds
+        len(body),
+        len(body),
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as f:
+        f.write(file_header)
+        f.write(packet_header)
+        f.write(body)
+
+
+def _build_pcap_path(root: Path, prefix: str, sensor_id: str, when: datetime) -> Path:
+    category = SensorCategory.get(sensor_id)
+    if category is None:
+        raise ValueError(f"unknown sensor: {sensor_id}")
+    sensor_lower = sensor_id.lower()
+    timestamp = when.strftime(_TIMESTAMP_FORMAT)
+    parts = [prefix, _TEST_VEHICLE_ID, category, sensor_lower,
+             when.strftime("%Y%m%d"), when.strftime("%H"), when.strftime("%M"),
+             f"{sensor_lower}_{timestamp}.pcap"]
+    return root.joinpath(*[p for p in parts if p])
+
+
+@pytest.fixture(scope="session")
+def fake_pcaps() -> Iterator[FakePcapEnv]:
+    """fake PCAP 파일 set up + 세션 종료 시 cleanup."""
+    ProjectConfig.set_config(str(REPO_ROOT / "conf/application.conf"))
+    cfg = ProjectConfig.instance()
+    root = Path(cfg.storage_root)
+    prefix = cfg.storage_prefix or ""
+
+    vehicle_dir = root / prefix / _TEST_VEHICLE_ID
+
+    start_dt = datetime.strptime(_TEST_START, _TIMESTAMP_FORMAT)
+    end_dt = datetime.strptime(_TEST_END, _TIMESTAMP_FORMAT)
+
+    cursor = start_dt
+    while cursor <= end_dt:
+        for sensor_id in _TEST_SENSORS:
+            _write_minimal_pcap(_build_pcap_path(root, prefix, sensor_id, cursor), cursor)
+        cursor += timedelta(seconds=1)
+
+    try:
+        yield FakePcapEnv(
+            vehicle_id=_TEST_VEHICLE_ID,
+            sensor_id_list=list(_TEST_SENSORS),
+            start_time=_TEST_START,
+            end_time=_TEST_END,
+        )
+    finally:
+        if vehicle_dir.exists():
+            shutil.rmtree(vehicle_dir, ignore_errors=True)

--- a/tests/test_client/test_close.py
+++ b/tests/test_client/test_close.py
@@ -1,0 +1,19 @@
+from tests.test_client._lifecycle_helper import run_lifecycle_scenario
+
+
+def test_play_then_close(fake_pcaps):
+    """PlayableList → Play → Close 시나리오.
+
+    Close는 reader/sender thread를 모두 join — Stop과 동일 동작 (replayer 미러).
+    """
+    result = run_lifecycle_scenario(
+        vehicle_id=fake_pcaps.vehicle_id,
+        sensor_id_list=fake_pcaps.sensor_id_list,
+        start_time=fake_pcaps.start_time,
+        end_time=fake_pcaps.end_time,
+        lifecycle_req_id="PD_300",
+        lifecycle_rep_id="PD_301",
+    )
+
+    assert result.lifecycle_rep["protocol_id"] == "PD_301"
+    print(f"[client] close code={result.lifecycle_rep.get('code')} reason={result.lifecycle_rep.get('reason')}")

--- a/tests/test_client/test_pause.py
+++ b/tests/test_client/test_pause.py
@@ -1,0 +1,21 @@
+from tests.test_client._lifecycle_helper import run_lifecycle_scenario
+
+
+def test_play_then_pause(fake_pcaps):
+    """PlayableList → Play → Pause 시나리오.
+
+    full flow:
+        client → REST_SERVER → STREAMER Manager (PAUSE) → STREAMER Module
+              ← REST_SERVER ← MESSAGE_BRIDGE ← STREAMER Manager (PD_PAUSE_REP)
+    """
+    result = run_lifecycle_scenario(
+        vehicle_id=fake_pcaps.vehicle_id,
+        sensor_id_list=fake_pcaps.sensor_id_list,
+        start_time=fake_pcaps.start_time,
+        end_time=fake_pcaps.end_time,
+        lifecycle_req_id="PD_400",
+        lifecycle_rep_id="PD_401",
+    )
+
+    assert result.lifecycle_rep["protocol_id"] == "PD_401"
+    print(f"[client] pause code={result.lifecycle_rep.get('code')} reason={result.lifecycle_rep.get('reason')}")

--- a/tests/test_client/test_seek.py
+++ b/tests/test_client/test_seek.py
@@ -1,0 +1,26 @@
+from tests.test_client._lifecycle_helper import run_lifecycle_scenario
+
+
+def test_play_then_seek(fake_pcaps):
+    """PlayableList → Play → Seek 시나리오.
+
+    Seek는 PCAP reader cursor 재설정 — section 범위 안의 다른 시각으로 이동.
+    """
+    seek_target = {"value": None}
+
+    def remember_seek(section: dict) -> None:
+        seek_target["value"] = section["startTime"]
+
+    result = run_lifecycle_scenario(
+        vehicle_id=fake_pcaps.vehicle_id,
+        sensor_id_list=fake_pcaps.sensor_id_list,
+        start_time=fake_pcaps.start_time,
+        end_time=fake_pcaps.end_time,
+        lifecycle_req_id="PD_500",
+        lifecycle_rep_id="PD_501",
+        extra_payload={"start_time": fake_pcaps.start_time},
+        on_section=remember_seek,
+    )
+
+    assert result.lifecycle_rep["protocol_id"] == "PD_501"
+    print(f"[client] seek code={result.lifecycle_rep.get('code')} reason={result.lifecycle_rep.get('reason')}")

--- a/tests/test_client/test_stop.py
+++ b/tests/test_client/test_stop.py
@@ -1,0 +1,19 @@
+from tests.test_client._lifecycle_helper import run_lifecycle_scenario
+
+
+def test_play_then_stop(fake_pcaps):
+    """PlayableList → Play → Stop 시나리오.
+
+    Stop은 reader/sender thread를 모두 join.
+    """
+    result = run_lifecycle_scenario(
+        vehicle_id=fake_pcaps.vehicle_id,
+        sensor_id_list=fake_pcaps.sensor_id_list,
+        start_time=fake_pcaps.start_time,
+        end_time=fake_pcaps.end_time,
+        lifecycle_req_id="PD_600",
+        lifecycle_rep_id="PD_601",
+    )
+
+    assert result.lifecycle_rep["protocol_id"] == "PD_601"
+    print(f"[client] stop code={result.lifecycle_rep.get('code')} reason={result.lifecycle_rep.get('reason')}")


### PR DESCRIPTION
## Summary
- `tests/test_client/conftest.py` — session-scoped `fake_pcaps` fixture: 최소 Ethernet/UDP PCAP를 격리된 `vehicle-test-lifecycle` 경로에 4초 분량 생성, 세션 종료 시 cleanup.
- `tests/test_client/_lifecycle_helper.py` — PlayableList → Play → 라이프사이클 한 종 시나리오 runner. 4개 테스트가 공유.
- `tests/test_client/test_{pause,seek,close,stop}.py` — 각 라이프사이클(PD_400/PD_500/PD_300/PD_600) 송수신 e2e.
- `scripts/dev.sh` — 4개 신규 테스트 pytest 라인 추가.

## Notes
- 현재 `DOWNLOAD_MANAGER`는 PlayableList 성공 후 `DOWNLOAD_READY`에 남아 `WAIT` 복귀를 하지 않는 동작이라, dev.sh 연속 실행 시 2번째 PD_100부터 `INVALID_REQUEST`가 발생함. 본 PR의 테스트 코드 자체는 정상이며, DOWNLOAD 본체 구현(별도 Task) 완료 후 dev.sh 연속 실행이 전 구간 통과하게 될 자산.
- 단일 테스트만 검증할 때는 4개 앱 fresh 재시작 후 1개 pytest 실행 권장.

## Related Issues
- close #80