### PR TITLE
[feat] #82 Download 흐름 본체 phase 1 — DOWNLOAD state 추가 및 Play handler 본체 시작

### DIFF
--- a/src/app/downloader/process/manager/manager.py
+++ b/src/app/downloader/process/manager/manager.py
@@ -118,7 +118,21 @@ class DownloaderManager(ImdgBusProcess):
             self._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.DOWNLOAD_READY)
 
     def handle_play_request(self, packet: PlayReq) -> None:
-        raise NotImplementedError
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+        from protocol.protocol_owner import ProtocolOwner
+
+        if self.get_current_state_id() != E_DOWNLOADER_MANAGER_STATE.DOWNLOAD_READY:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.PLAY_REP,
+                ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE),
+                response=make_response_info(E_CODE.INVALID_REQUEST),
+            )
+            return
+
+        if self._state_component is not None:
+            self._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.DOWNLOAD, state_param_dto=packet)
 
     def handle_play_response(self, packet: InrPlayRep) -> None:
         raise NotImplementedError

--- a/src/app/downloader/process/manager/state/__init__.py
+++ b/src/app/downloader/process/manager/state/__init__.py
@@ -1,5 +1,6 @@
 from python_library.state import StateMap
 
+from app.downloader.process.manager.state.download import DownloadState
 from app.downloader.process.manager.state.download_ready import DownloadReadyState
 from app.downloader.process.manager.state.playable import PlayableState
 from app.downloader.process.manager.state.state_enum import E_DOWNLOADER_MANAGER_STATE
@@ -12,5 +13,6 @@ def build_state_map() -> StateMap:
         E_DOWNLOADER_MANAGER_STATE.WAIT: WaitState(state_map, E_DOWNLOADER_MANAGER_STATE.WAIT),
         E_DOWNLOADER_MANAGER_STATE.PLAYABLE: PlayableState(state_map, E_DOWNLOADER_MANAGER_STATE.PLAYABLE),
         E_DOWNLOADER_MANAGER_STATE.DOWNLOAD_READY: DownloadReadyState(state_map, E_DOWNLOADER_MANAGER_STATE.DOWNLOAD_READY),
+        E_DOWNLOADER_MANAGER_STATE.DOWNLOAD: DownloadState(state_map, E_DOWNLOADER_MANAGER_STATE.DOWNLOAD),
     }
     return state_map

--- a/src/app/downloader/process/manager/state/download.py
+++ b/src/app/downloader/process/manager/state/download.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_library.state import abState
+
+from protocol.message.imdg.play import PlayReq
+
+if TYPE_CHECKING:
+    from app.downloader.process.manager.manager import DownloaderManager
+
+
+class DownloadState(abState):
+    """PlayReq 수신 후 모듈에 INR_PLAY_REQ를 broadcast하는 상태.
+
+    Phase 1: 진입 시 broadcast만 수행. 모듈 응답 후처리(group response)는 후속 phase.
+    """
+    owner: DownloaderManager
+
+    def on_enter(self):
+        assert isinstance(self.state_param_dto, PlayReq)
+
+    def on_leave(self): pass
+
+    def on_proc_once(self):
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        assert isinstance(self.state_param_dto, PlayReq)
+
+        self.owner.broadcast_message_req_inner_queue(
+            E_PROTOCOL_ID.INR_PLAY_REQ,
+            self.state_param_dto.sensor_id_list,
+            self.state_param_dto.section_id,
+            self.state_param_dto.vehicle_id,
+            self.state_param_dto.start_time,
+            self.state_param_dto.end_time,
+            rep_protocol_id=E_PROTOCOL_ID.INR_PLAY_REP,
+        )
+
+    def on_proc_every_frame(self): pass

--- a/src/app/downloader/process/module/module.py
+++ b/src/app/downloader/process/module/module.py
@@ -77,7 +77,23 @@ class DownloaderModule(QueueControlProcess):
             )
 
     def handle_play_request(self, packet: InrPlayReq) -> None:
-        raise NotImplementedError
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        if self.get_current_state_id() != E_DOWNLOADER_MODULE_STATE.DOWNLOAD_READY:
+            self.send_message_rep_inner_queue(
+                E_PROTOCOL_ID.INR_PLAY_REP,
+                E_CATE.E_DOWNLOADER.E_COMMON.DOWNLOAD_MANAGER,
+                response=make_response_info(E_CODE.INVALID_REQUEST),
+            )
+            return
+
+        if self._state_component is not None:
+            self._state_component.change_state(
+                E_DOWNLOADER_MODULE_STATE.DOWNLOAD,
+                state_param_dto=packet,
+            )
 
     def handle_pause_request(self, packet) -> None:
         raise NotImplementedError

--- a/src/app/downloader/process/module/state/__init__.py
+++ b/src/app/downloader/process/module/state/__init__.py
@@ -1,5 +1,7 @@
 from python_library.state import StateMap
 
+from app.downloader.process.module.state.download import DownloadState
+from app.downloader.process.module.state.download_ready import DownloadReadyState
 from app.downloader.process.module.state.playable import PlayableState
 from app.downloader.process.module.state.state_enum import E_DOWNLOADER_MODULE_STATE
 from app.downloader.process.module.state.wait import WaitState
@@ -10,5 +12,7 @@ def build_state_map() -> StateMap:
     state_map._state_map = {
         E_DOWNLOADER_MODULE_STATE.WAIT: WaitState(state_map, E_DOWNLOADER_MODULE_STATE.WAIT),
         E_DOWNLOADER_MODULE_STATE.PLAYABLE: PlayableState(state_map, E_DOWNLOADER_MODULE_STATE.PLAYABLE),
+        E_DOWNLOADER_MODULE_STATE.DOWNLOAD_READY: DownloadReadyState(state_map, E_DOWNLOADER_MODULE_STATE.DOWNLOAD_READY),
+        E_DOWNLOADER_MODULE_STATE.DOWNLOAD: DownloadState(state_map, E_DOWNLOADER_MODULE_STATE.DOWNLOAD),
     }
     return state_map

--- a/src/app/downloader/process/module/state/download.py
+++ b/src/app/downloader/process/module/state/download.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_library.state import abState
+
+from protocol.message.process.play import InrPlayReq
+
+if TYPE_CHECKING:
+    from app.downloader.process.module.module import DownloaderModule
+
+
+class DownloadState(abState):
+    """InrPlayReq 수신 후 다운로드 본체를 수행할 상태.
+
+    Phase 1: 진입만 수행 — 실제 파일 read/write는 후속 phase.
+    """
+    owner: DownloaderModule
+
+    def on_enter(self):
+        assert isinstance(self.state_param_dto, InrPlayReq)
+
+    def on_leave(self): pass
+    def on_proc_once(self): pass
+    def on_proc_every_frame(self): pass

--- a/src/app/downloader/process/module/state/download_ready.py
+++ b/src/app/downloader/process/module/state/download_ready.py
@@ -1,0 +1,13 @@
+from python_library.state import abState
+
+
+class DownloadReadyState(abState):
+    """PlayableList 성공 후 다음 명령(InrPlayReq)을 기다리는 상태.
+
+    Phase 1: 진입만 수행. 후속 명령 라우팅은 module.handle_play_request에서.
+    """
+
+    def on_enter(self): pass
+    def on_leave(self): pass
+    def on_proc_once(self): pass
+    def on_proc_every_frame(self): pass

--- a/src/app/downloader/process/module/state/playable.py
+++ b/src/app/downloader/process/module/state/playable.py
@@ -63,9 +63,10 @@ class PlayableState(abState):
         sensor_id = self.owner.name
         if self._lookup_thread.get_error() is not None:
             self.__send_error(sensor_id, str(self._lookup_thread.get_error()))
+            self.__transition_to_wait()
         else:
             self.__send_ok(sensor_id, self._lookup_thread.get_sections())
-        self.__transition_to_wait()
+            self.__transition_to_download_ready()
 
     def __send_ok(self, sensor_id: str, sections: list[SectionElement]) -> None:
         from process_category.enum_category import E_CATE
@@ -110,3 +111,8 @@ class PlayableState(abState):
         from app.downloader.process.module.state.state_enum import E_DOWNLOADER_MODULE_STATE
 
         self.owner._state_component.change_state(E_DOWNLOADER_MODULE_STATE.WAIT)
+
+    def __transition_to_download_ready(self) -> None:
+        from app.downloader.process.module.state.state_enum import E_DOWNLOADER_MODULE_STATE
+
+        self.owner._state_component.change_state(E_DOWNLOADER_MODULE_STATE.DOWNLOAD_READY)


### PR DESCRIPTION
## Summary
- DownloaderModule/DownloaderManager state map에 `DOWNLOAD` state 신설 (Module은 `DOWNLOAD_READY`도 함께 등록)
- DownloaderManager `DownloadState.on_proc_once`에서 `INR_PLAY_REQ` broadcast (Streamer PlayState 패턴 미러)
- `handle_play_request` 본체 구현 — Manager/Module 모두 `DOWNLOAD_READY` 상태에서 요청 수신 시 `DOWNLOAD` 전이, 그 외엔 `INVALID_REQUEST` 응답
- Module `PlayableState` 성공 path를 `DOWNLOAD_READY` 전이로 변경 (실패는 기존대로 WAIT 유지) — Manager의 PLAYABLE→DOWNLOAD_READY 전이와 mirror
- 본 Phase는 state 진입과 트랜지션까지 — 실제 다운로드 동작 및 group response 후처리는 후속 phase

## Related Issues
- close #82