### PR TITLE
[feat] #84 Download 흐름 본체 phase 2 — Module DownloadState 본체 + Manager group response

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -2,6 +2,17 @@
 PROJECT_NAME = data-pipeline
 CHANNEL_NAME = test
 
+[STORAGE]
+ROOT = /home/shinminbeom/infra_glue/personal/data-pipeline/data
+PREFIX = raw
+
+; STORAGE_CACHE: downloader가 source에서 받아 로컬에 저장하는 캐시 경로.
+; 운영 환경에서 STORAGE는 원격(S3/MinIO)으로 교체되지만 STORAGE_CACHE는 항상 로컬.
+; streamer는 후속 phase에서 이 경로를 읽도록 전환 예정.
+[STORAGE_CACHE]
+ROOT = /home/shinminbeom/infra_glue/personal/data-pipeline/data
+PREFIX = cache
+
 [IMDG]
 SERVER_IP = 127.0.0.1
 ; SERVER_IP = redis
@@ -17,9 +28,6 @@ BIND_PORT = 9999
 STREAM_NAME = downloader_tasks
 GROUP_NAME = downloader_group
 
-[STORAGE]
-ROOT = /home/shinminbeom/infra_glue/personal/data-pipeline/data
-PREFIX = raw
 
 ; STREAM_OUTPUT: sensor 이름 → 송출 IP/PORT 매핑 (replayer 미러)
 ; 키 형식: <SENSOR_NAME>_IP / <SENSOR_NAME>_PORT (case-insensitive)

--- a/src/app/downloader/process/manager/manager.py
+++ b/src/app/downloader/process/manager/manager.py
@@ -4,10 +4,9 @@ from typing import Optional
 
 from common.process.imdg_bus_process import ImdgBusProcess
 from protocol.inr_protocol_matcher.inr_pair_state import E_PROTOCOL_PAIR_STATE
-from protocol.message.imdg.play import PlayReq, PlayRep
+from protocol.message.imdg.play import PlayReq
 from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
 from protocol.message.message import IMessage
-from protocol.message.process.play import InrPlayRep
 from protocol.section_element import SectionElementContainer
 
 from app.downloader.process.manager.state import (
@@ -134,8 +133,40 @@ class DownloaderManager(ImdgBusProcess):
         if self._state_component is not None:
             self._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.DOWNLOAD, state_param_dto=packet)
 
-    def handle_play_response(self, packet: InrPlayRep) -> None:
-        raise NotImplementedError
+    def handle_play_response(self, packet) -> None:
+        # 매처 경로(handle_play_group_response)가 후처리 — 개별 handler는 no-op.
+        pass
+
+    def handle_play_group_response(self, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]) -> None:
+        """모든 모듈의 INR_PLAY_REP 도착 시 매처 인프라가 발화.
+
+        PLAY_REP 송신 + WAIT 복귀를 한 곳에서 수행.
+        InnerQueueListener thread에서 실행되지만:
+          - send_message_rep_imdg → redis-py thread-safe
+          - change_state → 다음 메인 loop frame에 적용되는 reservation
+        """
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+        from protocol.protocol_owner import ProtocolOwner
+
+        bridge = ProtocolOwner.build(
+            E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE
+        )
+
+        if pair_state == E_PROTOCOL_PAIR_STATE.ERROR:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.PLAY_REP, bridge,
+                response=make_response_info(E_CODE.INVALID_REQUEST, "module error"),
+            )
+        else:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.PLAY_REP, bridge,
+                response=make_response_info(E_CODE.OK),
+            )
+
+        if self._state_component is not None:
+            self._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.WAIT)
 
     def handle_pause_request(self, packet) -> None:
         raise NotImplementedError

--- a/src/app/downloader/process/module/module.py
+++ b/src/app/downloader/process/module/module.py
@@ -23,6 +23,9 @@ class DownloaderModule(QueueControlProcess):
         self._storage: Optional[IStorage] = None
         self._storage_root: str = ""
         self._storage_prefix: str = ""
+        self._cache_storage: Optional[IStorage] = None
+        self._cache_storage_root: str = ""
+        self._cache_storage_prefix: str = ""
 
     def on_init(self):
         super().on_init()
@@ -31,6 +34,11 @@ class DownloaderModule(QueueControlProcess):
         self._storage_prefix = (config.storage_prefix or "").strip("/")
         self._storage = LocalStorageFactory(LocalStorageInfoFactory()).create_storage()
         self._storage.connect()
+
+        self._cache_storage_root = (config.cache_storage_root or "").rstrip("/")
+        self._cache_storage_prefix = (config.cache_storage_prefix or "").strip("/")
+        self._cache_storage = LocalStorageFactory(LocalStorageInfoFactory()).create_storage()
+        self._cache_storage.connect()
 
         self.set_state_component(
             build_state_map(),
@@ -54,6 +62,15 @@ class DownloaderModule(QueueControlProcess):
 
     def get_storage_prefix(self) -> str:
         return self._storage_prefix
+
+    def get_cache_storage(self) -> Optional[IStorage]:
+        return self._cache_storage
+
+    def get_cache_storage_root(self) -> str:
+        return self._cache_storage_root
+
+    def get_cache_storage_prefix(self) -> str:
+        return self._cache_storage_prefix
 
     def handle_playable_list_request(self, packet: InrPlayableListReq) -> None:
         from process_category.enum_category import E_CATE

--- a/src/app/downloader/process/module/state/download.py
+++ b/src/app/downloader/process/module/state/download.py
@@ -1,25 +1,103 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from python_library.state import abState
 
 from protocol.message.process.play import InrPlayReq
+
+from app.downloader.process.module.state.helper.download_thread import DownloadThread
 
 if TYPE_CHECKING:
     from app.downloader.process.module.module import DownloaderModule
 
 
 class DownloadState(abState):
-    """InrPlayReq 수신 후 다운로드 본체를 수행할 상태.
+    """InrPlayReq 수신 후 source storage → cache storage로 파일 전송.
 
-    Phase 1: 진입만 수행 — 실제 파일 read/write는 후속 phase.
+    on_proc_once: DownloadThread 시작 (source read → cache write)
+    on_proc_every_frame: thread 완료 polling → INR_PLAY_REP + WAIT 복귀
     """
     owner: DownloaderModule
 
+    def __init__(self, state_lists, state_id) -> None:
+        super().__init__(state_lists, state_id)
+        self._thread: Optional[DownloadThread] = None
+
     def on_enter(self):
         assert isinstance(self.state_param_dto, InrPlayReq)
+        self._thread = None
 
-    def on_leave(self): pass
-    def on_proc_once(self): pass
-    def on_proc_every_frame(self): pass
+    def on_leave(self):
+        self._thread = None
+
+    def on_proc_once(self):
+        from sensor_category.sensor_category import SensorCategory
+
+        assert isinstance(self.state_param_dto, InrPlayReq)
+        sensor_id = self.owner.name
+        category = SensorCategory.get(sensor_id)
+
+        if category is None:
+            self.__send_invalid_request(f"unknown sensor: {sensor_id}")
+            self.__transition_to_wait()
+            return
+
+        source_storage = self.owner.get_storage()
+        cache_storage = self.owner.get_cache_storage()
+        assert source_storage is not None
+        assert cache_storage is not None
+
+        self._thread = DownloadThread(
+            source_storage=source_storage,
+            cache_storage=cache_storage,
+            source_root=self.owner.get_storage_root(),
+            source_prefix=self.owner.get_storage_prefix(),
+            cache_root=self.owner.get_cache_storage_root(),
+            cache_prefix=self.owner.get_cache_storage_prefix(),
+            vehicle_id=self.state_param_dto.vehicle_id,
+            sensor_id=sensor_id,
+            category=category,
+            start_time=self.state_param_dto.start_time,
+            end_time=self.state_param_dto.end_time,
+        )
+        self._thread.start()
+
+    def on_proc_every_frame(self):
+        if self._thread is None:
+            return
+        if self._thread.is_alive():
+            return
+
+        if self._thread.get_error() is not None:
+            self.__send_invalid_request(str(self._thread.get_error()))
+        else:
+            self.__send_ok()
+        self.__transition_to_wait()
+
+    def __send_ok(self) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        self.owner.send_message_rep_inner_queue(
+            E_PROTOCOL_ID.INR_PLAY_REP,
+            E_CATE.E_DOWNLOADER.E_COMMON.DOWNLOAD_MANAGER,
+            response=make_response_info(E_CODE.OK),
+        )
+
+    def __send_invalid_request(self, reason: str) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        self.owner.send_message_rep_inner_queue(
+            E_PROTOCOL_ID.INR_PLAY_REP,
+            E_CATE.E_DOWNLOADER.E_COMMON.DOWNLOAD_MANAGER,
+            response=make_response_info(E_CODE.INVALID_REQUEST, reason=reason),
+        )
+
+    def __transition_to_wait(self) -> None:
+        from app.downloader.process.module.state.state_enum import E_DOWNLOADER_MODULE_STATE
+
+        self.owner._state_component.change_state(E_DOWNLOADER_MODULE_STATE.WAIT)

--- a/src/app/downloader/process/module/state/helper/download_thread.py
+++ b/src/app/downloader/process/module/state/helper/download_thread.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from python_library.storage.storage import IStorage
+from python_library.thread.thread import abThread
+
+
+MINUTE_FORMAT = "%Y%m%d%H%M"
+TIMESTAMP_FORMAT = "%Y%m%d%H%M%S"
+
+
+class DownloadThread(abThread):
+    """source storage → cache storage 파일 전송 thread.
+
+    LookupThread와 같은 분 단위 path 순회 패턴이지만, 매 파일을 read 후
+    cache로 write까지 수행. 운영에서는 source가 원격(S3/MinIO)으로 교체되고
+    cache는 항상 LocalStorage.
+    """
+
+    def __init__(
+        self,
+        source_storage: IStorage,
+        cache_storage: IStorage,
+        source_root: str,
+        source_prefix: str,
+        cache_root: str,
+        cache_prefix: str,
+        vehicle_id: str,
+        sensor_id: str,
+        category: str,
+        start_time: str,
+        end_time: str,
+    ) -> None:
+        super().__init__()
+        self._source_storage = source_storage
+        self._cache_storage = cache_storage
+        self._source_root = source_root
+        self._source_prefix = source_prefix
+        self._cache_root = cache_root
+        self._cache_prefix = cache_prefix
+        self._vehicle_id = vehicle_id
+        self._sensor_id = sensor_id
+        self._category = category
+        self._start_time = start_time
+        self._end_time = end_time
+
+        self._error: Exception | None = None
+        self._downloaded_count: int = 0
+
+    def action(self) -> None:
+        try:
+            self.__transfer_loop()
+        except Exception as e:
+            self._error = e
+
+    def get_error(self) -> Exception | None:
+        return self._error
+
+    def get_downloaded_count(self) -> int:
+        return self._downloaded_count
+
+    def __transfer_loop(self) -> None:
+        cursor = datetime.strptime(self._start_time[:12], MINUTE_FORMAT)
+        end_minute = datetime.strptime(self._end_time[:12], MINUTE_FORMAT)
+
+        while cursor <= end_minute:
+            if self.is_stop():
+                return
+
+            src_minute_path = self.__build_minute_path(
+                self._source_root, self._source_prefix, cursor
+            )
+            cache_minute_path = self.__build_minute_path(
+                self._cache_root, self._cache_prefix, cursor
+            )
+
+            for storage_file in self._source_storage.get_file_list(src_minute_path):
+                if self.is_stop():
+                    return
+                if storage_file.is_dir():
+                    continue
+
+                file_name = storage_file.get_file_name()
+                ts = file_name.split(".")[0][-14:]
+                if len(ts) != 14 or not ts.isdigit():
+                    continue
+                if not (self._start_time <= ts <= self._end_time):
+                    continue
+
+                src_path = f"{src_minute_path}{file_name}"
+                cache_path = f"{cache_minute_path}{file_name}"
+
+                data = self._source_storage.read(src_path)
+                self._cache_storage.write(cache_path, data)
+                self._downloaded_count += 1
+
+            cursor += timedelta(minutes=1)
+
+    def __build_base_path(self, root: str, prefix: str) -> str:
+        parts = [prefix, self._vehicle_id, self._category, self._sensor_id.lower()]
+        suffix = "/".join(p for p in parts if p)
+        return f"{root}/{suffix}"
+
+    def __build_minute_path(self, root: str, prefix: str, when: datetime) -> str:
+        base = self.__build_base_path(root, prefix)
+        return f"{base}/{when.strftime('%Y%m%d')}/{when.strftime('%H')}/{when.strftime('%M')}/"

--- a/src/config/project_config.py
+++ b/src/config/project_config.py
@@ -13,6 +13,7 @@ class ProjectConfig(AppConfig):
         REST = "REST"
         STREAM = "STREAM"
         STORAGE = "STORAGE"
+        STORAGE_CACHE = "STORAGE_CACHE"
         STREAM_OUTPUT = "STREAM_OUTPUT"
         PLAYER = "PLAYER"
 
@@ -91,6 +92,15 @@ class ProjectConfig(AppConfig):
         )
         self.storage_prefix = self.get_config(
             ProjectConfig.E_CATE_TYPE.STORAGE, ProjectConfig.E_CATE_ELE_STORAGE.PREFIX
+        )
+
+        # Cache storage: downloader가 source에서 받아 저장하는 로컬 경로.
+        # 키 형식은 STORAGE와 동일(ROOT/PREFIX)이라 E_CATE_ELE_STORAGE를 재사용.
+        self.cache_storage_root = self.get_config(
+            ProjectConfig.E_CATE_TYPE.STORAGE_CACHE, ProjectConfig.E_CATE_ELE_STORAGE.ROOT
+        )
+        self.cache_storage_prefix = self.get_config(
+            ProjectConfig.E_CATE_TYPE.STORAGE_CACHE, ProjectConfig.E_CATE_ELE_STORAGE.PREFIX
         )
 
         # Player buffer 설정


### PR DESCRIPTION
## Summary
- STORAGE_CACHE 섹션 신설로 source(운영: S3/MinIO 등 원격) vs cache(항상 local) 분리 도입 — downloader가 source에서 받아 cache로 저장하는 2-storage 모델의 기반.
- DownloaderModule이 source/cache 2개 IStorage 인스턴스를 보유하도록 확장.
- DownloadThread helper 신설 — LookupThread와 동일한 분 단위 path 순회 패턴으로 source.read() → cache.write() 수행.
- Module DownloadState 본체 구현: thread 시작 후 polling으로 완료 감지 → INR_PLAY_REP 송신 + WAIT 복귀.
- Manager handle_play_group_response 구현: 모든 모듈 응답 도착 시 PLAY_REP 송신 + WAIT 복귀 (playable_list group response와 동일 패턴).
- 후속 작업: streamer source를 cache로 전환 + Manager 트리거 순서 정렬은 phase 3, 4에서 분리 처리.

## Related Issues
- close #84