### PR TITLE
[refactor] #90 PAUSE/SEEK lifecycle에서 DOWNLOADER 제거 — STREAMER 전용 정렬

### DIFF
--- a/src/app/downloader/process/manager/manager.py
+++ b/src/app/downloader/process/manager/manager.py
@@ -174,18 +174,6 @@ class DownloaderManager(ImdgBusProcess):
         if self._state_component is not None:
             self._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.WAIT)
 
-    def handle_pause_request(self, packet) -> None:
-        raise NotImplementedError
-
-    def handle_pause_response(self, packet) -> None:
-        raise NotImplementedError
-
-    def handle_seek_request(self, packet) -> None:
-        raise NotImplementedError
-
-    def handle_seek_response(self, packet) -> None:
-        raise NotImplementedError
-
     def handle_close_request(self, packet) -> None:
         raise NotImplementedError
 

--- a/src/protocol/protocol_meta.py
+++ b/src/protocol/protocol_meta.py
@@ -410,7 +410,7 @@ class ProtocolMeta:
             ),
         )
 
-        # PAUSE_REQ → BRIDGE / STREAMER / DOWNLOADER (Play와 동일 broadcast 패턴)
+        # PAUSE_REQ → BRIDGE / STREAMER (DOWNLOADER 무관 — 재생 흐름 전용)
         cls._register(
             E_PROTOCOL_ID.PAUSE_REQ,
             ProtocolEntry(
@@ -423,7 +423,6 @@ class ProtocolMeta:
                 receive_handlers={
                     E_CATE.MESSAGE_BRIDGE: ProtocolHandler.pause_request,
                     E_CATE.STREAMER: ProtocolHandler.pause_request,
-                    E_CATE.DOWNLOADER: ProtocolHandler.pause_request,
                 },
             ),
         )
@@ -521,7 +520,7 @@ class ProtocolMeta:
             ),
         )
 
-        # SEEK_REQ → BRIDGE / STREAMER / DOWNLOADER
+        # SEEK_REQ → BRIDGE / STREAMER (DOWNLOADER 무관 — 재생 흐름 전용)
         cls._register(
             E_PROTOCOL_ID.SEEK_REQ,
             ProtocolEntry(
@@ -535,7 +534,6 @@ class ProtocolMeta:
                 receive_handlers={
                     E_CATE.MESSAGE_BRIDGE: ProtocolHandler.seek_request,
                     E_CATE.STREAMER: ProtocolHandler.seek_request,
-                    E_CATE.DOWNLOADER: ProtocolHandler.seek_request,
                 },
             ),
         )


### PR DESCRIPTION
## Summary
- PAUSE/SEEK은 PCAP 재생 흐름(STREAMER) 전용이라 DOWNLOADER에 라우팅될 의미가 없음. broadcast로 DOWNLOADER에 도착하면 `NotImplementedError`가 매번 raise되던 노이즈를 제거.
- `protocol_meta.PAUSE_REQ`/`SEEK_REQ`의 `receive_handlers`에서 DOWNLOADER 항목 제거. 이제 BRIDGE/STREAMER 2 receivers로만 라우팅.
- `DownloaderManager`에서 `handle_pause_request`/`handle_pause_response`/`handle_seek_request`/`handle_seek_response` 4개 메서드 제거. 모두 `NotImplementedError` raise하던 dead code.
- CLOSE/STOP은 DOWNLOADER도 진행 중 download cancel/cleanup이 필요할 가능성이 있어 별도 Issue로 분리 처리 예정.

## Related Issues
- close #90