### PR TITLE
[feat] #92 Downloader CLOSE/STOP lifecycle 본체 — 진행 중 download cancel + WAIT 복귀

### DIFF
--- a/src/app/downloader/process/manager/manager.py
+++ b/src/app/downloader/process/manager/manager.py
@@ -4,8 +4,10 @@ from typing import Optional
 
 from common.process.imdg_bus_process import ImdgBusProcess
 from protocol.inr_protocol_matcher.inr_pair_state import E_PROTOCOL_PAIR_STATE
+from protocol.message.imdg.close import CloseReq
 from protocol.message.imdg.play import PlayReq
 from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
+from protocol.message.imdg.stop import StopReq
 from protocol.message.message import IMessage
 from protocol.section_element import SectionElementContainer
 
@@ -174,14 +176,68 @@ class DownloaderManager(ImdgBusProcess):
         if self._state_component is not None:
             self._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.WAIT)
 
-    def handle_close_request(self, packet) -> None:
-        raise NotImplementedError
+    def handle_close_request(self, packet: CloseReq) -> None:
+        # Close는 어떤 state에서든 의미 있음(현재 활성 흐름 종료) — state 체크 생략하고 일단 CLOSE 진입.
+        if self._state_component is not None:
+            self._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.CLOSE, state_param_dto=packet)
 
     def handle_close_response(self, packet) -> None:
-        raise NotImplementedError
+        # 매처 경로(handle_close_group_response)가 후처리 — 개별 handler는 no-op.
+        pass
 
-    def handle_stop_request(self, packet) -> None:
-        raise NotImplementedError
+    def handle_close_group_response(self, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+        from protocol.protocol_owner import ProtocolOwner
+
+        bridge = ProtocolOwner.build(
+            E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE
+        )
+
+        if pair_state == E_PROTOCOL_PAIR_STATE.ERROR:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.CLOSE_REP, bridge,
+                response=make_response_info(E_CODE.INVALID_REQUEST, "module error"),
+            )
+        else:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.CLOSE_REP, bridge,
+                response=make_response_info(E_CODE.OK),
+            )
+
+        if self._state_component is not None:
+            self._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.WAIT)
+
+    def handle_stop_request(self, packet: StopReq) -> None:
+        # Stop은 어떤 state에서든 의미 있음(현재 활성 흐름 종료) — state 체크 생략하고 일단 STOP 진입.
+        if self._state_component is not None:
+            self._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.STOP, state_param_dto=packet)
 
     def handle_stop_response(self, packet) -> None:
-        raise NotImplementedError
+        # 매처 경로(handle_stop_group_response)가 후처리 — 개별 handler는 no-op.
+        pass
+
+    def handle_stop_group_response(self, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]) -> None:
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+        from protocol.protocol_owner import ProtocolOwner
+
+        bridge = ProtocolOwner.build(
+            E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE
+        )
+
+        if pair_state == E_PROTOCOL_PAIR_STATE.ERROR:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.STOP_REP, bridge,
+                response=make_response_info(E_CODE.INVALID_REQUEST, "module error"),
+            )
+        else:
+            self.send_message_rep_imdg(
+                E_PROTOCOL_ID.STOP_REP, bridge,
+                response=make_response_info(E_CODE.OK),
+            )
+
+        if self._state_component is not None:
+            self._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.WAIT)

--- a/src/app/downloader/process/manager/state/__init__.py
+++ b/src/app/downloader/process/manager/state/__init__.py
@@ -1,9 +1,11 @@
 from python_library.state import StateMap
 
+from app.downloader.process.manager.state.close import CloseState
 from app.downloader.process.manager.state.download import DownloadState
 from app.downloader.process.manager.state.download_ready import DownloadReadyState
 from app.downloader.process.manager.state.playable import PlayableState
 from app.downloader.process.manager.state.state_enum import E_DOWNLOADER_MANAGER_STATE
+from app.downloader.process.manager.state.stop import StopState
 from app.downloader.process.manager.state.wait import WaitState
 
 
@@ -14,5 +16,7 @@ def build_state_map() -> StateMap:
         E_DOWNLOADER_MANAGER_STATE.PLAYABLE: PlayableState(state_map, E_DOWNLOADER_MANAGER_STATE.PLAYABLE),
         E_DOWNLOADER_MANAGER_STATE.DOWNLOAD_READY: DownloadReadyState(state_map, E_DOWNLOADER_MANAGER_STATE.DOWNLOAD_READY),
         E_DOWNLOADER_MANAGER_STATE.DOWNLOAD: DownloadState(state_map, E_DOWNLOADER_MANAGER_STATE.DOWNLOAD),
+        E_DOWNLOADER_MANAGER_STATE.STOP: StopState(state_map, E_DOWNLOADER_MANAGER_STATE.STOP),
+        E_DOWNLOADER_MANAGER_STATE.CLOSE: CloseState(state_map, E_DOWNLOADER_MANAGER_STATE.CLOSE),
     }
     return state_map

--- a/src/app/downloader/process/manager/state/close.py
+++ b/src/app/downloader/process/manager/state/close.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_library.state import abState
+
+from protocol.message.imdg.close import CloseReq
+
+if TYPE_CHECKING:
+    from app.downloader.process.manager.manager import DownloaderManager
+
+
+class CloseState(abState):
+    owner: DownloaderManager
+
+    def on_enter(self):
+        assert isinstance(self.state_param_dto, CloseReq)
+
+    def on_leave(self): pass
+
+    def on_proc_once(self):
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        # 활성 sensor module list 추적은 후속 작업 — placeholder는 빈 리스트.
+        receivers: list[str] = []
+
+        self.owner.broadcast_message_req_inner_queue(
+            E_PROTOCOL_ID.INR_CLOSE_REQ,
+            receivers,
+            rep_protocol_id=E_PROTOCOL_ID.INR_CLOSE_REP,
+        )
+
+    def on_proc_every_frame(self): pass

--- a/src/app/downloader/process/manager/state/stop.py
+++ b/src/app/downloader/process/manager/state/stop.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_library.state import abState
+
+from protocol.message.imdg.stop import StopReq
+
+if TYPE_CHECKING:
+    from app.downloader.process.manager.manager import DownloaderManager
+
+
+class StopState(abState):
+    owner: DownloaderManager
+
+    def on_enter(self):
+        assert isinstance(self.state_param_dto, StopReq)
+
+    def on_leave(self): pass
+
+    def on_proc_once(self):
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        # 활성 sensor module list 추적은 후속 작업 — placeholder는 빈 리스트.
+        receivers: list[str] = []
+
+        self.owner.broadcast_message_req_inner_queue(
+            E_PROTOCOL_ID.INR_STOP_REQ,
+            receivers,
+            rep_protocol_id=E_PROTOCOL_ID.INR_STOP_REP,
+        )
+
+    def on_proc_every_frame(self): pass

--- a/src/app/downloader/process/module/module.py
+++ b/src/app/downloader/process/module/module.py
@@ -8,13 +8,16 @@ from python_library.storage.storage import IStorage
 
 from common.process.queue_control_process import QueueControlProcess
 from config.project_config import ProjectConfig
+from protocol.message.process.close import InrCloseReq
 from protocol.message.process.play import InrPlayReq
 from protocol.message.process.playable_list import InrPlayableListReq
+from protocol.message.process.stop import InrStopReq
 
 from app.downloader.process.module.state import (
     E_DOWNLOADER_MODULE_STATE,
     build_state_map,
 )
+from app.downloader.process.module.state.helper.download_thread import DownloadThread
 
 
 class DownloaderModule(QueueControlProcess):
@@ -26,6 +29,8 @@ class DownloaderModule(QueueControlProcess):
         self._cache_storage: Optional[IStorage] = None
         self._cache_storage_root: str = ""
         self._cache_storage_prefix: str = ""
+        # 진행 중 DownloadThread 참조. CLOSE/STOP state에서 정지 신호 발신용.
+        self._download_thread: Optional[DownloadThread] = None
 
     def on_init(self):
         super().on_init()
@@ -71,6 +76,12 @@ class DownloaderModule(QueueControlProcess):
 
     def get_cache_storage_prefix(self) -> str:
         return self._cache_storage_prefix
+
+    def get_download_thread(self) -> Optional[DownloadThread]:
+        return self._download_thread
+
+    def set_download_thread(self, thread: Optional[DownloadThread]) -> None:
+        self._download_thread = thread
 
     def handle_playable_list_request(self, packet: InrPlayableListReq) -> None:
         from process_category.enum_category import E_CATE
@@ -118,8 +129,18 @@ class DownloaderModule(QueueControlProcess):
     def handle_seek_request(self, packet) -> None:
         raise NotImplementedError
 
-    def handle_close_request(self, packet) -> None:
-        raise NotImplementedError
+    def handle_close_request(self, packet: InrCloseReq) -> None:
+        # 어느 state에서든 진입 허용 (streamer pattern 동일).
+        if self._state_component is not None:
+            self._state_component.change_state(
+                E_DOWNLOADER_MODULE_STATE.CLOSE,
+                state_param_dto=packet,
+            )
 
-    def handle_stop_request(self, packet) -> None:
-        raise NotImplementedError
+    def handle_stop_request(self, packet: InrStopReq) -> None:
+        # 어느 state에서든 진입 허용 (streamer pattern 동일).
+        if self._state_component is not None:
+            self._state_component.change_state(
+                E_DOWNLOADER_MODULE_STATE.STOP,
+                state_param_dto=packet,
+            )

--- a/src/app/downloader/process/module/state/__init__.py
+++ b/src/app/downloader/process/module/state/__init__.py
@@ -1,9 +1,11 @@
 from python_library.state import StateMap
 
+from app.downloader.process.module.state.close import CloseState
 from app.downloader.process.module.state.download import DownloadState
 from app.downloader.process.module.state.download_ready import DownloadReadyState
 from app.downloader.process.module.state.playable import PlayableState
 from app.downloader.process.module.state.state_enum import E_DOWNLOADER_MODULE_STATE
+from app.downloader.process.module.state.stop import StopState
 from app.downloader.process.module.state.wait import WaitState
 
 
@@ -14,5 +16,7 @@ def build_state_map() -> StateMap:
         E_DOWNLOADER_MODULE_STATE.PLAYABLE: PlayableState(state_map, E_DOWNLOADER_MODULE_STATE.PLAYABLE),
         E_DOWNLOADER_MODULE_STATE.DOWNLOAD_READY: DownloadReadyState(state_map, E_DOWNLOADER_MODULE_STATE.DOWNLOAD_READY),
         E_DOWNLOADER_MODULE_STATE.DOWNLOAD: DownloadState(state_map, E_DOWNLOADER_MODULE_STATE.DOWNLOAD),
+        E_DOWNLOADER_MODULE_STATE.STOP: StopState(state_map, E_DOWNLOADER_MODULE_STATE.STOP),
+        E_DOWNLOADER_MODULE_STATE.CLOSE: CloseState(state_map, E_DOWNLOADER_MODULE_STATE.CLOSE),
     }
     return state_map

--- a/src/app/downloader/process/module/state/close.py
+++ b/src/app/downloader/process/module/state/close.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_library.state import abState
+
+from protocol.message.process.close import InrCloseReq
+
+if TYPE_CHECKING:
+    from app.downloader.process.module.module import DownloaderModule
+
+
+class CloseState(abState):
+    """진행 중 DownloadThread 정지 + None reset. streamer #78 pattern 미러."""
+    owner: DownloaderModule
+
+    def on_enter(self):
+        assert isinstance(self.state_param_dto, InrCloseReq)
+
+    def on_leave(self): pass
+
+    def on_proc_once(self):
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        thread = self.owner.get_download_thread()
+        if thread is not None:
+            try:
+                thread.stop()
+                thread.join()
+            except Exception:
+                pass
+            self.owner.set_download_thread(None)
+
+        self.owner.send_message_rep_inner_queue(
+            E_PROTOCOL_ID.INR_CLOSE_REP,
+            E_CATE.E_DOWNLOADER.E_COMMON.DOWNLOAD_MANAGER,
+            response=make_response_info(E_CODE.OK),
+        )
+
+        from app.downloader.process.module.state.state_enum import E_DOWNLOADER_MODULE_STATE
+        self.owner._state_component.change_state(E_DOWNLOADER_MODULE_STATE.WAIT)
+
+    def on_proc_every_frame(self): pass

--- a/src/app/downloader/process/module/state/download.py
+++ b/src/app/downloader/process/module/state/download.py
@@ -61,6 +61,8 @@ class DownloadState(abState):
             start_time=self.state_param_dto.start_time,
             end_time=self.state_param_dto.end_time,
         )
+        # CLOSE/STOP state가 진행 중 thread를 정지시킬 수 있도록 owner에 등록.
+        self.owner.set_download_thread(self._thread)
         self._thread.start()
 
     def on_proc_every_frame(self):
@@ -73,6 +75,8 @@ class DownloadState(abState):
             self.__send_invalid_request(str(self._thread.get_error()))
         else:
             self.__send_ok()
+        # 정상 완료 또는 에러로 thread가 끝나면 owner 등록 해제.
+        self.owner.set_download_thread(None)
         self.__transition_to_wait()
 
     def __send_ok(self) -> None:

--- a/src/app/downloader/process/module/state/stop.py
+++ b/src/app/downloader/process/module/state/stop.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_library.state import abState
+
+from protocol.message.process.stop import InrStopReq
+
+if TYPE_CHECKING:
+    from app.downloader.process.module.module import DownloaderModule
+
+
+class StopState(abState):
+    """진행 중 DownloadThread 정지 + None reset. Close와 동일 동작 (replayer 미러)."""
+    owner: DownloaderModule
+
+    def on_enter(self):
+        assert isinstance(self.state_param_dto, InrStopReq)
+
+    def on_leave(self): pass
+
+    def on_proc_once(self):
+        from process_category.enum_category import E_CATE
+        from protocol.protocol_code import E_CODE, make_response_info
+        from protocol.protocol_meta import E_PROTOCOL_ID
+
+        thread = self.owner.get_download_thread()
+        if thread is not None:
+            try:
+                thread.stop()
+                thread.join()
+            except Exception:
+                pass
+            self.owner.set_download_thread(None)
+
+        self.owner.send_message_rep_inner_queue(
+            E_PROTOCOL_ID.INR_STOP_REP,
+            E_CATE.E_DOWNLOADER.E_COMMON.DOWNLOAD_MANAGER,
+            response=make_response_info(E_CODE.OK),
+        )
+
+        from app.downloader.process.module.state.state_enum import E_DOWNLOADER_MODULE_STATE
+        self.owner._state_component.change_state(E_DOWNLOADER_MODULE_STATE.WAIT)
+
+    def on_proc_every_frame(self): pass

--- a/src/protocol/protocol_meta.py
+++ b/src/protocol/protocol_meta.py
@@ -700,6 +700,7 @@ class ProtocolMeta:
                 },
                 inr_group_receive_handlers={
                     E_CATE.STREAMER: ProtocolHandler.inr_close_response_group,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_close_response_group,
                 },
             ),
         )
@@ -810,6 +811,7 @@ class ProtocolMeta:
                 },
                 inr_group_receive_handlers={
                     E_CATE.STREAMER: ProtocolHandler.inr_stop_response_group,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_stop_response_group,
                 },
             ),
         )


### PR DESCRIPTION
## Summary
- `DownloaderModule`에 `_download_thread` 필드 + getter/setter 추가. DownloadState가 시작 시 owner에 등록하고 정상 완료/에러 시 해제. streamer의 player 보유 패턴 미러.
- Module/Manager 양쪽에 CloseState/StopState 신설. Module은 `thread.stop() + join → INR_*_REP OK → WAIT`, Manager는 `broadcast INR_*_REQ → group response에서 *_REP + WAIT` (streamer #78 미러).
- DownloaderManager의 `handle_close_request`/`handle_stop_request`에서 `NotImplementedError` 제거 후 state 전이로 대체. 어느 state에서든 진입 허용. `*_response`는 matcher 경로 위임(no-op), `*_group_response`가 후처리 담당.
- `protocol_meta`의 INR_CLOSE_REP/INR_STOP_REP `inr_group_receive_handlers`에 DOWNLOADER 등록. phase 2에서 INR_PLAY_REP에 누락됐던 dead code 패턴이 CLOSE/STOP에서도 재발하지 않도록 차단.

## Related Issues
- close #92