### PR TITLE
[refactor] #94 INR_PAUSE_REQ/INR_SEEK_REQ에서 DOWNLOADER Module 제거

### DIFF
--- a/src/app/downloader/process/module/module.py
+++ b/src/app/downloader/process/module/module.py
@@ -123,12 +123,6 @@ class DownloaderModule(QueueControlProcess):
                 state_param_dto=packet,
             )
 
-    def handle_pause_request(self, packet) -> None:
-        raise NotImplementedError
-
-    def handle_seek_request(self, packet) -> None:
-        raise NotImplementedError
-
     def handle_close_request(self, packet: InrCloseReq) -> None:
         # 어느 state에서든 진입 허용 (streamer pattern 동일).
         if self._state_component is not None:

--- a/src/protocol/protocol_meta.py
+++ b/src/protocol/protocol_meta.py
@@ -444,7 +444,7 @@ class ProtocolMeta:
             ),
         )
 
-        # INR_PAUSE_REQ → STREAMER (Module) / DOWNLOADER (Module)
+        # INR_PAUSE_REQ → STREAMER (Module) — DOWNLOADER 무관 (재생 흐름 전용)
         cls._register(
             E_PROTOCOL_ID.INR_PAUSE_REQ,
             ProtocolEntry(
@@ -456,7 +456,6 @@ class ProtocolMeta:
                 decoder=InrPauseReq.from_json,
                 receive_handlers={
                     E_CATE.STREAMER: ProtocolHandler.inr_pause_request,
-                    E_CATE.DOWNLOADER: ProtocolHandler.inr_pause_request,
                 },
             ),
         )
@@ -555,7 +554,7 @@ class ProtocolMeta:
             ),
         )
 
-        # INR_SEEK_REQ → STREAMER (Module) / DOWNLOADER (Module)
+        # INR_SEEK_REQ → STREAMER (Module) — DOWNLOADER 무관 (재생 흐름 전용)
         cls._register(
             E_PROTOCOL_ID.INR_SEEK_REQ,
             ProtocolEntry(
@@ -568,7 +567,6 @@ class ProtocolMeta:
                 decoder=InrSeekReq.from_json,
                 receive_handlers={
                     E_CATE.STREAMER: ProtocolHandler.inr_seek_request,
-                    E_CATE.DOWNLOADER: ProtocolHandler.inr_seek_request,
                 },
             ),
         )


### PR DESCRIPTION
## Summary
- INR_PAUSE_REQ/INR_SEEK_REQ는 PCAP 재생 흐름(STREAMER) 전용이라 DOWNLOADER Module로 라우팅될 의미가 없음. `protocol_meta`의 receive_handlers에서 DOWNLOADER 제거.
- `DownloaderModule`의 `handle_pause_request`/`handle_seek_request` 2개 메서드 제거. 둘 다 `NotImplementedError` raise하던 dead code.
- #91이 IMDG 레벨(PAUSE_REQ/SEEK_REQ)에서 정리한 패턴을 INR 레벨(Manager→Module)에서 동일하게 마무리.

## Related Issues
- close #94