### PR TITLE
[chore] #100 주석 정리 — replayer 인용 + stale Phase/placeholder 제거

### DIFF
--- a/src/app/downloader/process/manager/state/download.py
+++ b/src/app/downloader/process/manager/state/download.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 class DownloadState(abState):
     """PlayReq 수신 후 모듈에 INR_PLAY_REQ를 broadcast하는 상태.
 
-    Phase 1: 진입 시 broadcast만 수행. 모듈 응답 후처리(group response)는 후속 phase.
+    모듈 응답 후처리(group response)는 DownloaderManager.handle_play_group_response.
     """
     owner: DownloaderManager
 

--- a/src/app/downloader/process/module/state/download_ready.py
+++ b/src/app/downloader/process/module/state/download_ready.py
@@ -4,7 +4,7 @@ from python_library.state import abState
 class DownloadReadyState(abState):
     """PlayableList 성공 후 다음 명령(InrPlayReq)을 기다리는 상태.
 
-    Phase 1: 진입만 수행. 후속 명령 라우팅은 module.handle_play_request에서.
+    후속 명령 라우팅은 module.handle_play_request에서 DOWNLOAD state로 전이.
     """
 
     def on_enter(self): pass

--- a/src/app/downloader/process/module/state/stop.py
+++ b/src/app/downloader/process/module/state/stop.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class StopState(abState):
-    """진행 중 DownloadThread 정지 + None reset. Close와 동일 동작 (replayer 미러)."""
+    """진행 중 DownloadThread 정지 + None reset. Close와 동일 동작."""
     owner: DownloaderModule
 
     def on_enter(self):

--- a/src/app/streamer/process/module/module.py
+++ b/src/app/streamer/process/module/module.py
@@ -88,11 +88,7 @@ class StreamerModule(QueueControlProcess):
             )
 
     def handle_pause_request(self, packet: InrPauseReq) -> None:
-        from process_category.enum_category import E_CATE
-        from protocol.protocol_code import E_CODE, make_response_info
-        from protocol.protocol_meta import E_PROTOCOL_ID
-
-        # placeholder — 실제 GStreamer pause 흐름 미이식. 어떤 state든 일단 PAUSE 진입 후 즉시 OK.
+        # 어느 state에서든 PAUSE 진입 허용.
         if self._state_component is not None:
             self._state_component.change_state(
                 E_STREAMER_MODULE_STATE.PAUSE,
@@ -100,7 +96,7 @@ class StreamerModule(QueueControlProcess):
             )
 
     def handle_seek_request(self, packet: InrSeekReq) -> None:
-        # placeholder — 실제 GStreamer seek 흐름 미이식. 어떤 state든 일단 SEEK 진입 후 즉시 OK.
+        # 어느 state에서든 SEEK 진입 허용.
         if self._state_component is not None:
             self._state_component.change_state(
                 E_STREAMER_MODULE_STATE.SEEK,
@@ -108,7 +104,7 @@ class StreamerModule(QueueControlProcess):
             )
 
     def handle_close_request(self, packet: InrCloseReq) -> None:
-        # placeholder — 실제 GStreamer close 흐름 미이식. 어떤 state든 일단 CLOSE 진입 후 즉시 OK.
+        # 어느 state에서든 CLOSE 진입 허용.
         if self._state_component is not None:
             self._state_component.change_state(
                 E_STREAMER_MODULE_STATE.CLOSE,
@@ -116,7 +112,7 @@ class StreamerModule(QueueControlProcess):
             )
 
     def handle_stop_request(self, packet: InrStopReq) -> None:
-        # placeholder — 실제 GStreamer stop 흐름 미이식. 어떤 state든 일단 STOP 진입 후 즉시 OK.
+        # 어느 state에서든 STOP 진입 허용.
         if self._state_component is not None:
             self._state_component.change_state(
                 E_STREAMER_MODULE_STATE.STOP,

--- a/src/app/streamer/process/module/state/close.py
+++ b/src/app/streamer/process/module/state/close.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class CloseState(abState):
-    """player 종료 + None reset. replayer 미러 — stop과 동일 동작."""
+    """player 종료 + None reset. stop과 동일 동작."""
     owner: StreamerModule
 
     def on_enter(self):

--- a/src/app/streamer/process/module/state/helper/pcap_player.py
+++ b/src/app/streamer/process/module/state/helper/pcap_player.py
@@ -22,7 +22,7 @@ class PcapPlayer:
         start() — 두 thread 시작
         pause() / resume() — sender 송출 일시정지/재개 (reader는 영향 없음)
         seek(start, end) — reader 교체 + pool clear + 재시작 (sender는 그대로)
-        stop() / close() — reader/sender 모두 join (replayer 미러 — 동일 동작)
+        stop() / close() — reader/sender 모두 join (둘 다 동일 동작)
     """
 
     def __init__(
@@ -112,7 +112,7 @@ class PcapPlayer:
         self._sender.join()
 
     def close(self) -> None:
-        """replayer 미러 — stop과 동일 동작."""
+        """stop과 동일 동작."""
         self.stop()
 
     def join(self) -> None:

--- a/src/app/streamer/process/module/state/helper/pcap_reader_thread.py
+++ b/src/app/streamer/process/module/state/helper/pcap_reader_thread.py
@@ -24,7 +24,6 @@ class PcapReaderThread(abThread):
     """sensor 1개에 대한 1초 단위 PCAP 파일 read producer thread.
 
     buffer가 가득 차면 wait, ready_threshold만큼 읽으면 ready_callback 호출.
-    replayer App/Streamer/GStreamer/State/Helper/PcapReaderThread.py 미러.
     """
 
     def __init__(

--- a/src/app/streamer/process/module/state/helper/pcap_sender_thread.py
+++ b/src/app/streamer/process/module/state/helper/pcap_sender_thread.py
@@ -17,7 +17,6 @@ class PcapSenderThread(abThread):
     """PcapPool에서 패킷 꺼내 time.offset_time 만큼 sleep 후 UDP 송출 consumer thread.
 
     pause_event 세팅 시 송출 일시정지 (Pool은 그대로 둠 — reader 계속 채울 수 있음).
-    replayer App/Streamer/GStreamer/State/Helper/PcapSenderThread.py 미러.
     """
 
     def __init__(

--- a/src/app/streamer/process/module/state/play.py
+++ b/src/app/streamer/process/module/state/play.py
@@ -16,9 +16,8 @@ if TYPE_CHECKING:
 class PlayState(abState):
     """Reader/Sender 2 thread + Pool buffer로 PCAP 재생.
 
-    Phase 2: PcapPlayer.start() → reader가 buffer threshold 도달하면 on_ready 발화
-            → INR_PLAY_REP OK 응답. sender는 background로 계속 송출.
-    실 동작 제어(Pause/Seek/Stop)는 Phase 3.
+    PcapPlayer.start() → reader가 buffer threshold 도달하면 on_ready 발화
+    → INR_PLAY_REP OK 응답. sender는 background로 계속 송출.
     """
     owner: StreamerModule
 

--- a/src/app/streamer/process/module/state/stop.py
+++ b/src/app/streamer/process/module/state/stop.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class StopState(abState):
-    """player 종료 + None reset. Close와 동일 동작 (replayer 미러)."""
+    """player 종료 + None reset. Close와 동일 동작."""
     owner: StreamerModule
 
     def on_enter(self):

--- a/src/common/process/queue_control_process.py
+++ b/src/common/process/queue_control_process.py
@@ -72,7 +72,7 @@ class QueueControlProcess(StepProcess):
         )
 
     # ---------------------------
-    # INR group matcher (replayer 패턴 미러)
+    # INR group matcher
     # ---------------------------
     def enable_inr_matcher(self) -> QueueControlProcess:
         """builder. broadcast scatter-gather 그룹 콜백을 받을 process가 호출."""

--- a/src/protocol/inr_protocol_matcher/inr_protocol_container.py
+++ b/src/protocol/inr_protocol_matcher/inr_protocol_container.py
@@ -18,7 +18,7 @@ class InrProtocolContainer:
 
     def append(self, packet: IMessage) -> None:
         self._responses.append(packet)
-        # response.code가 OK가 아니면 에러로 간주 (replayer ERROR 패턴)
+        # response.code가 OK가 아니면 에러로 간주
         if packet.response is not None and packet.response.code not in ("", "OK"):
             self._has_error = True
 

--- a/src/protocol/message/external/external.py
+++ b/src/protocol/message/external/external.py
@@ -22,7 +22,7 @@ class pdPacket(IMessage):
 
 @dataclass
 class pdResponsePacket(pdPacket):
-    """RESPONSE PD packet. code/code_nm/reason 직접 보유 (replayer 동일)."""
+    """RESPONSE PD packet. code/code_nm/reason 직접 보유."""
     message_direction: E_PROTOCOL_MESSAGE_DIRECTION = E_PROTOCOL_MESSAGE_DIRECTION.RESPONSE
     code: str = ""
     code_nm: str = ""

--- a/src/protocol/protocol_meta.py
+++ b/src/protocol/protocol_meta.py
@@ -290,7 +290,7 @@ class ProtocolMeta:
             ),
         )
 
-        # PLAY_REQ → BRIDGE / STREAMER / DOWNLOADER (replayer broadcast 패턴)
+        # PLAY_REQ → BRIDGE / STREAMER / DOWNLOADER (broadcast dispatch — BRIDGE 외엔 sender filter로 차단)
         cls._register(
             E_PROTOCOL_ID.PLAY_REQ,
             ProtocolEntry(

--- a/tests/test_client/test_close.py
+++ b/tests/test_client/test_close.py
@@ -4,7 +4,7 @@ from tests.test_client._lifecycle_helper import run_lifecycle_scenario
 def test_play_then_close(fake_pcaps):
     """PlayableList → Play → Close 시나리오.
 
-    Close는 reader/sender thread를 모두 join — Stop과 동일 동작 (replayer 미러).
+    Close는 reader/sender thread를 모두 join — Stop과 동일 동작.
     """
     result = run_lifecycle_scenario(
         vehicle_id=fake_pcaps.vehicle_id,

--- a/tests/test_client/test_close_udp.py
+++ b/tests/test_client/test_close_udp.py
@@ -5,8 +5,8 @@ from tests.test_client._udp_helper import validate_lifecycle_stops_udp
 def test_close_stops_udp(fake_pcaps):
     """Play 중 UDP packet 도착 → PD_CLOSE → packet 멈춤 검증.
 
-    Close는 player.close() (= stop과 동일 동작, replayer 미러). reader/sender
-    모두 join되어 송출 중단됨을 e2e로 확인.
+    Close는 player.close() (= stop과 동일 동작). reader/sender 모두 join되어
+    송출 중단됨을 e2e로 확인.
     """
     validate_lifecycle_stops_udp(
         fake_pcaps,


### PR DESCRIPTION
## Summary
- "replayer 미러" 인용 주석 13곳 일괄 제거. state files(streamer/downloader), helpers(pcap_player/reader/sender), protocol meta, inr matcher, message external, tests에 흩어져 있던 인용 정리.
- stale Phase N 주석 갱신: `play.py`의 Phase 2/3 안내, `manager/state/download.py`의 Phase 1 안내, `module/state/download_ready.py`의 Phase 1 안내 — 모두 후속 phase 머지 후 outdated 상태였음.
- stale "GStreamer placeholder" 주석 4곳 제거: `streamer/module/module.py`의 pause/seek/close/stop handlers — Phase 3 (#78) 본체 구현 후 stale.
- Manager의 "활성 sensor module list 추적 후속 작업" placeholder 5곳은 유지 (실제로 미구현이라 의미 있음).
- 코드 동작 변경 없음 (주석 only).

## Related Issues
- close #100