### PR TITLE
[refactor] #102 ProtocolHandler dispatcher 카테고리별 분할 — process 구체 타입 strict화

### DIFF
--- a/src/app/downloader/process/manager/manager.py
+++ b/src/app/downloader/process/manager/manager.py
@@ -6,7 +6,8 @@ from common.process.imdg_bus_process import ImdgBusProcess
 from protocol.inr_protocol_matcher.inr_pair_state import E_PROTOCOL_PAIR_STATE
 from protocol.message.imdg.close import CloseReq
 from protocol.message.imdg.play import PlayReq
-from protocol.message.imdg.playable_list import PlayableListReq, PlayableListRep
+from protocol.message.imdg.playable_list import PlayableListReq
+from protocol.message.process.playable_list import InrPlayableListRep
 from protocol.message.imdg.stop import StopReq
 from protocol.message.message import IMessage
 from protocol.section_element import SectionElementContainer
@@ -59,7 +60,7 @@ class DownloaderManager(ImdgBusProcess):
         if self._state_component is not None:
             self._state_component.change_state(E_DOWNLOADER_MANAGER_STATE.PLAYABLE, state_param_dto=packet)
 
-    def handle_playable_list_response(self, packet: PlayableListRep) -> None:
+    def handle_playable_list_response(self, packet: InrPlayableListRep) -> None:
         # 매처 경로(handle_playable_list_group_response)가 후처리 담당 — 개별 handler는 no-op.
         pass
 

--- a/src/protocol/protocol_handler.py
+++ b/src/protocol/protocol_handler.py
@@ -1,13 +1,23 @@
 """모든 receive handler dispatcher를 한 곳에 모은 라우팅 테이블.
 
-- 시그니처는 모두 (process, wrapper, packet) 통일
-- 비즈니스 로직은 각 process 클래스의 handle_* instance method로 위임
-- duck typing — protocol_id가 여러 카테고리에 라우팅돼도 dispatcher는 1개
+- dispatcher 시그니처는 (process: IProcess, wrapper, packet) — 호출자(라우팅 테이블)와의
+  Callable contravariance를 만족시키기 위해 추상 base 타입 IProcess로 받는다.
+- 함수 안에서 assert isinstance로 카테고리별 구체 타입 narrowing (C# 다운캐스트 의미론).
+- 카테고리별 분할 — 같은 메시지라도 process 타입이 다르면 dispatcher 분리
+  (예: play_request → bridge_play_request / streamer_play_request / downloader_play_request)
 
 group dispatcher는 시그니처가 다른 (process, pair_state, packets).
 """
 from __future__ import annotations
 
+from python_library.process.process import IProcess
+
+from app.downloader.process.manager.manager import DownloaderManager
+from app.downloader.process.module.module import DownloaderModule
+from app.message_bridge.process.message_bridge_process import MessageBridgeProcess
+from app.rest.process.socket_io_process import SocketIOProcess
+from app.streamer.process.manager.manager import StreamerManager
+from app.streamer.process.module.module import StreamerModule
 from protocol.inr_protocol_matcher.inr_pair_state import E_PROTOCOL_PAIR_STATE
 from protocol.message.external.ui.close import PDCloseReq, PDCloseRep
 from protocol.message.external.ui.pause import PDPauseReq, PDPauseRep
@@ -32,218 +42,392 @@ from protocol.protocol_wrapper import ProtocolWrapper
 
 
 class ProtocolHandler:
-    # ---------------------------
-    # External (PD) — REST_SERVER 진입/송출
-    # ---------------------------
+    # ============================================================
+    # External (PD) — REST_SERVER (SocketIOProcess)
+    # ============================================================
     @staticmethod
-    def pd_playable_list_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def pd_playable_list_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, SocketIOProcess)
         assert isinstance(packet, PDPlayableListReq)
         process.handle_playable_list_request(packet)
 
     @staticmethod
-    def pd_playable_list_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def pd_playable_list_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, SocketIOProcess)
         assert isinstance(packet, PDPlayableListRep)
         process.handle_playable_list_response(packet)
 
     @staticmethod
-    def pd_play_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def pd_play_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, SocketIOProcess)
         assert isinstance(packet, PDPlayReq)
         process.handle_play_request(packet)
 
     @staticmethod
-    def pd_play_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def pd_play_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, SocketIOProcess)
         assert isinstance(packet, PDPlayRep)
         process.handle_play_response(packet)
 
     @staticmethod
-    def pd_pause_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def pd_pause_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, SocketIOProcess)
         assert isinstance(packet, PDPauseReq)
         process.handle_pause_request(packet)
 
     @staticmethod
-    def pd_pause_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def pd_pause_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, SocketIOProcess)
         assert isinstance(packet, PDPauseRep)
         process.handle_pause_response(packet)
 
     @staticmethod
-    def pd_seek_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def pd_seek_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, SocketIOProcess)
         assert isinstance(packet, PDSeekReq)
         process.handle_seek_request(packet)
 
     @staticmethod
-    def pd_seek_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def pd_seek_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, SocketIOProcess)
         assert isinstance(packet, PDSeekRep)
         process.handle_seek_response(packet)
 
     @staticmethod
-    def pd_close_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def pd_close_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, SocketIOProcess)
         assert isinstance(packet, PDCloseReq)
         process.handle_close_request(packet)
 
     @staticmethod
-    def pd_close_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def pd_close_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, SocketIOProcess)
         assert isinstance(packet, PDCloseRep)
         process.handle_close_response(packet)
 
     @staticmethod
-    def pd_stop_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def pd_stop_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, SocketIOProcess)
         assert isinstance(packet, PDStopReq)
         process.handle_stop_request(packet)
 
     @staticmethod
-    def pd_stop_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def pd_stop_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, SocketIOProcess)
         assert isinstance(packet, PDStopRep)
         process.handle_stop_response(packet)
 
-    # ---------------------------
+    # ============================================================
     # IMDG — 앱 간 통신
-    # ---------------------------
+    # ============================================================
+    # --- PlayableList ---
     @staticmethod
-    def playable_list_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def bridge_playable_list_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, MessageBridgeProcess)
         assert isinstance(packet, PlayableListReq)
         process.handle_playable_list_request(packet)
 
     @staticmethod
-    def playable_list_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def downloader_playable_list_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, DownloaderManager)
+        assert isinstance(packet, PlayableListReq)
+        process.handle_playable_list_request(packet)
+
+    @staticmethod
+    def bridge_playable_list_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, MessageBridgeProcess)
         assert isinstance(packet, PlayableListRep)
         process.handle_playable_list_response(packet)
 
+    # --- Play ---
     @staticmethod
-    def play_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def bridge_play_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, MessageBridgeProcess)
         assert isinstance(packet, PlayReq)
         process.handle_play_request(packet)
 
     @staticmethod
-    def play_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def streamer_play_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, StreamerManager)
+        assert isinstance(packet, PlayReq)
+        process.handle_play_request(packet)
+
+    @staticmethod
+    def downloader_play_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, DownloaderManager)
+        assert isinstance(packet, PlayReq)
+        process.handle_play_request(packet)
+
+    @staticmethod
+    def bridge_play_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, MessageBridgeProcess)
         assert isinstance(packet, PlayRep)
         process.handle_play_response(packet)
 
+    # --- Pause ---
     @staticmethod
-    def pause_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def bridge_pause_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, MessageBridgeProcess)
         assert isinstance(packet, PauseReq)
         process.handle_pause_request(packet)
 
     @staticmethod
-    def pause_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def streamer_pause_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, StreamerManager)
+        assert isinstance(packet, PauseReq)
+        process.handle_pause_request(packet)
+
+    @staticmethod
+    def bridge_pause_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, MessageBridgeProcess)
         assert isinstance(packet, PauseRep)
         process.handle_pause_response(packet)
 
+    # --- Seek ---
     @staticmethod
-    def seek_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def bridge_seek_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, MessageBridgeProcess)
         assert isinstance(packet, SeekReq)
         process.handle_seek_request(packet)
 
     @staticmethod
-    def seek_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def streamer_seek_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, StreamerManager)
+        assert isinstance(packet, SeekReq)
+        process.handle_seek_request(packet)
+
+    @staticmethod
+    def bridge_seek_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, MessageBridgeProcess)
         assert isinstance(packet, SeekRep)
         process.handle_seek_response(packet)
 
+    # --- Close ---
     @staticmethod
-    def close_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def bridge_close_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, MessageBridgeProcess)
         assert isinstance(packet, CloseReq)
         process.handle_close_request(packet)
 
     @staticmethod
-    def close_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def streamer_close_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, StreamerManager)
+        assert isinstance(packet, CloseReq)
+        process.handle_close_request(packet)
+
+    @staticmethod
+    def downloader_close_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, DownloaderManager)
+        assert isinstance(packet, CloseReq)
+        process.handle_close_request(packet)
+
+    @staticmethod
+    def bridge_close_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, MessageBridgeProcess)
         assert isinstance(packet, CloseRep)
         process.handle_close_response(packet)
 
+    # --- Stop ---
     @staticmethod
-    def stop_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def bridge_stop_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, MessageBridgeProcess)
         assert isinstance(packet, StopReq)
         process.handle_stop_request(packet)
 
     @staticmethod
-    def stop_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def streamer_stop_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, StreamerManager)
+        assert isinstance(packet, StopReq)
+        process.handle_stop_request(packet)
+
+    @staticmethod
+    def downloader_stop_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, DownloaderManager)
+        assert isinstance(packet, StopReq)
+        process.handle_stop_request(packet)
+
+    @staticmethod
+    def bridge_stop_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, MessageBridgeProcess)
         assert isinstance(packet, StopRep)
         process.handle_stop_response(packet)
 
-    # ---------------------------
-    # PROCESS (INR) — 앱 내 통신
-    # ---------------------------
+    # ============================================================
+    # PROCESS (INR) request — 앱 내 통신 (Module)
+    # ============================================================
     @staticmethod
-    def inr_playable_list_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def inr_downloader_playable_list_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, DownloaderModule)
         assert isinstance(packet, InrPlayableListReq)
         process.handle_playable_list_request(packet)
 
     @staticmethod
-    def inr_playable_list_response(process, wrapper: ProtocolWrapper, packet: IMessage):
-        assert isinstance(packet, InrPlayableListRep)
-        process.handle_playable_list_response(packet)
-
-    @staticmethod
-    def inr_play_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def inr_streamer_play_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, StreamerModule)
         assert isinstance(packet, InrPlayReq)
         process.handle_play_request(packet)
 
     @staticmethod
-    def inr_play_response(process, wrapper: ProtocolWrapper, packet: IMessage):
-        assert isinstance(packet, InrPlayRep)
-        process.handle_play_response(packet)
+    def inr_downloader_play_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, DownloaderModule)
+        assert isinstance(packet, InrPlayReq)
+        process.handle_play_request(packet)
 
     @staticmethod
-    def inr_pause_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def inr_streamer_pause_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, StreamerModule)
         assert isinstance(packet, InrPauseReq)
         process.handle_pause_request(packet)
 
     @staticmethod
-    def inr_pause_response(process, wrapper: ProtocolWrapper, packet: IMessage):
-        assert isinstance(packet, InrPauseRep)
-        process.handle_pause_response(packet)
-
-    @staticmethod
-    def inr_seek_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def inr_streamer_seek_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, StreamerModule)
         assert isinstance(packet, InrSeekReq)
         process.handle_seek_request(packet)
 
     @staticmethod
-    def inr_seek_response(process, wrapper: ProtocolWrapper, packet: IMessage):
-        assert isinstance(packet, InrSeekRep)
-        process.handle_seek_response(packet)
-
-    @staticmethod
-    def inr_close_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def inr_streamer_close_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, StreamerModule)
         assert isinstance(packet, InrCloseReq)
         process.handle_close_request(packet)
 
     @staticmethod
-    def inr_close_response(process, wrapper: ProtocolWrapper, packet: IMessage):
-        assert isinstance(packet, InrCloseRep)
-        process.handle_close_response(packet)
+    def inr_downloader_close_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, DownloaderModule)
+        assert isinstance(packet, InrCloseReq)
+        process.handle_close_request(packet)
 
     @staticmethod
-    def inr_stop_request(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def inr_streamer_stop_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, StreamerModule)
         assert isinstance(packet, InrStopReq)
         process.handle_stop_request(packet)
 
     @staticmethod
-    def inr_stop_response(process, wrapper: ProtocolWrapper, packet: IMessage):
+    def inr_downloader_stop_request(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, DownloaderModule)
+        assert isinstance(packet, InrStopReq)
+        process.handle_stop_request(packet)
+
+    # ============================================================
+    # PROCESS (INR) response — 앱 내 통신 (Manager)
+    # ============================================================
+    @staticmethod
+    def inr_downloader_playable_list_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, DownloaderManager)
+        assert isinstance(packet, InrPlayableListRep)
+        process.handle_playable_list_response(packet)
+
+    @staticmethod
+    def inr_streamer_play_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, StreamerManager)
+        assert isinstance(packet, InrPlayRep)
+        process.handle_play_response(packet)
+
+    @staticmethod
+    def inr_downloader_play_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, DownloaderManager)
+        assert isinstance(packet, InrPlayRep)
+        process.handle_play_response(packet)
+
+    @staticmethod
+    def inr_streamer_pause_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, StreamerManager)
+        assert isinstance(packet, InrPauseRep)
+        process.handle_pause_response(packet)
+
+    @staticmethod
+    def inr_streamer_seek_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, StreamerManager)
+        assert isinstance(packet, InrSeekRep)
+        process.handle_seek_response(packet)
+
+    @staticmethod
+    def inr_streamer_close_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, StreamerManager)
+        assert isinstance(packet, InrCloseRep)
+        process.handle_close_response(packet)
+
+    @staticmethod
+    def inr_downloader_close_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, DownloaderManager)
+        assert isinstance(packet, InrCloseRep)
+        process.handle_close_response(packet)
+
+    @staticmethod
+    def inr_streamer_stop_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, StreamerManager)
         assert isinstance(packet, InrStopRep)
         process.handle_stop_response(packet)
 
-    # ---------------------------
-    # Group dispatchers — 시그니처 다름 (process, pair_state, packets)
-    # ---------------------------
     @staticmethod
-    def inr_playable_list_response_group(process, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]):
+    def inr_downloader_stop_response(process: IProcess, wrapper: ProtocolWrapper, packet: IMessage):
+        assert isinstance(process, DownloaderManager)
+        assert isinstance(packet, InrStopRep)
+        process.handle_stop_response(packet)
+
+    # ============================================================
+    # Group dispatchers (Manager) — 시그니처 다름 (process, pair_state, packets)
+    # ============================================================
+    @staticmethod
+    def inr_downloader_playable_list_response_group(
+        process: IProcess, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]
+    ):
+        assert isinstance(process, DownloaderManager)
         process.handle_playable_list_group_response(pair_state, packets)
 
     @staticmethod
-    def inr_play_response_group(process, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]):
+    def inr_streamer_play_response_group(
+        process: IProcess, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]
+    ):
+        assert isinstance(process, StreamerManager)
         process.handle_play_group_response(pair_state, packets)
 
     @staticmethod
-    def inr_pause_response_group(process, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]):
+    def inr_downloader_play_response_group(
+        process: IProcess, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]
+    ):
+        assert isinstance(process, DownloaderManager)
+        process.handle_play_group_response(pair_state, packets)
+
+    @staticmethod
+    def inr_streamer_pause_response_group(
+        process: IProcess, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]
+    ):
+        assert isinstance(process, StreamerManager)
         process.handle_pause_group_response(pair_state, packets)
 
     @staticmethod
-    def inr_seek_response_group(process, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]):
+    def inr_streamer_seek_response_group(
+        process: IProcess, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]
+    ):
+        assert isinstance(process, StreamerManager)
         process.handle_seek_group_response(pair_state, packets)
 
     @staticmethod
-    def inr_close_response_group(process, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]):
+    def inr_streamer_close_response_group(
+        process: IProcess, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]
+    ):
+        assert isinstance(process, StreamerManager)
         process.handle_close_group_response(pair_state, packets)
 
     @staticmethod
-    def inr_stop_response_group(process, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]):
+    def inr_downloader_close_response_group(
+        process: IProcess, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]
+    ):
+        assert isinstance(process, DownloaderManager)
+        process.handle_close_group_response(pair_state, packets)
+
+    @staticmethod
+    def inr_streamer_stop_response_group(
+        process: IProcess, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]
+    ):
+        assert isinstance(process, StreamerManager)
+        process.handle_stop_group_response(pair_state, packets)
+
+    @staticmethod
+    def inr_downloader_stop_response_group(
+        process: IProcess, pair_state: E_PROTOCOL_PAIR_STATE, packets: list[IMessage]
+    ):
+        assert isinstance(process, DownloaderManager)
         process.handle_stop_group_response(pair_state, packets)

--- a/src/protocol/protocol_meta.py
+++ b/src/protocol/protocol_meta.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, Mapping, ClassVar
 
-from python_library.process.process import abProcess
+from python_library.process.process import IProcess
 
 from protocol.inr_protocol_matcher.inr_pair_state import E_PROTOCOL_PAIR_STATE
 from protocol.message.message import IMessage
@@ -13,8 +13,8 @@ from protocol.protocol_wrapper import ProtocolWrapper
 ReceiverKey = Any
 FactoryFn = Callable[..., IMessage]
 DecoderFn = Callable[[str], IMessage]
-HandlerFn = Callable[[abProcess, ProtocolWrapper, IMessage], Any]
-GroupHandlerFn = Callable[[abProcess, E_PROTOCOL_PAIR_STATE, list[IMessage]], Any]
+HandlerFn = Callable[[IProcess, ProtocolWrapper, IMessage], Any]
+GroupHandlerFn = Callable[[IProcess, E_PROTOCOL_PAIR_STATE, list[IMessage]], Any]
 
 
 class E_PROTOCOL_ID(Enum):
@@ -182,8 +182,8 @@ class ProtocolMeta:
                 ),
                 decoder=PlayableListReq.from_json,
                 receive_handlers={
-                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.playable_list_request,
-                    E_CATE.DOWNLOADER: ProtocolHandler.playable_list_request,
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.bridge_playable_list_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.downloader_playable_list_request,
                 },
             ),
         )
@@ -202,7 +202,7 @@ class ProtocolMeta:
                 ),
                 decoder=PlayableListRep.from_json,
                 receive_handlers={
-                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.playable_list_response,
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.bridge_playable_list_response,
                 },
             ),
         )
@@ -221,7 +221,7 @@ class ProtocolMeta:
                 ),
                 decoder=InrPlayableListReq.from_json,
                 receive_handlers={
-                    E_CATE.DOWNLOADER: ProtocolHandler.inr_playable_list_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_downloader_playable_list_request,
                 },
             ),
         )
@@ -240,10 +240,10 @@ class ProtocolMeta:
                 ),
                 decoder=InrPlayableListRep.from_json,
                 receive_handlers={
-                    E_CATE.DOWNLOADER: ProtocolHandler.inr_playable_list_response,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_downloader_playable_list_response,
                 },
                 inr_group_receive_handlers={
-                    E_CATE.DOWNLOADER: ProtocolHandler.inr_playable_list_response_group,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_downloader_playable_list_response_group,
                 },
             ),
         )
@@ -306,9 +306,9 @@ class ProtocolMeta:
                 ),
                 decoder=PlayReq.from_json,
                 receive_handlers={
-                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.play_request,
-                    E_CATE.STREAMER: ProtocolHandler.play_request,
-                    E_CATE.DOWNLOADER: ProtocolHandler.play_request,
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.bridge_play_request,
+                    E_CATE.STREAMER: ProtocolHandler.streamer_play_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.downloader_play_request,
                 },
             ),
         )
@@ -325,7 +325,7 @@ class ProtocolMeta:
                 ),
                 decoder=PlayRep.from_json,
                 receive_handlers={
-                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.play_response,
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.bridge_play_response,
                 },
             ),
         )
@@ -345,8 +345,8 @@ class ProtocolMeta:
                 ),
                 decoder=InrPlayReq.from_json,
                 receive_handlers={
-                    E_CATE.STREAMER: ProtocolHandler.inr_play_request,
-                    E_CATE.DOWNLOADER: ProtocolHandler.inr_play_request,
+                    E_CATE.STREAMER: ProtocolHandler.inr_streamer_play_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_downloader_play_request,
                 },
             ),
         )
@@ -363,12 +363,12 @@ class ProtocolMeta:
                 ),
                 decoder=InrPlayRep.from_json,
                 receive_handlers={
-                    E_CATE.STREAMER: ProtocolHandler.inr_play_response,
-                    E_CATE.DOWNLOADER: ProtocolHandler.inr_play_response,
+                    E_CATE.STREAMER: ProtocolHandler.inr_streamer_play_response,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_downloader_play_response,
                 },
                 inr_group_receive_handlers={
-                    E_CATE.STREAMER: ProtocolHandler.inr_play_response_group,
-                    E_CATE.DOWNLOADER: ProtocolHandler.inr_play_response_group,
+                    E_CATE.STREAMER: ProtocolHandler.inr_streamer_play_response_group,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_downloader_play_response_group,
                 },
             ),
         )
@@ -421,8 +421,8 @@ class ProtocolMeta:
                 ),
                 decoder=PauseReq.from_json,
                 receive_handlers={
-                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.pause_request,
-                    E_CATE.STREAMER: ProtocolHandler.pause_request,
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.bridge_pause_request,
+                    E_CATE.STREAMER: ProtocolHandler.streamer_pause_request,
                 },
             ),
         )
@@ -439,7 +439,7 @@ class ProtocolMeta:
                 ),
                 decoder=PauseRep.from_json,
                 receive_handlers={
-                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.pause_response,
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.bridge_pause_response,
                 },
             ),
         )
@@ -455,7 +455,7 @@ class ProtocolMeta:
                 ),
                 decoder=InrPauseReq.from_json,
                 receive_handlers={
-                    E_CATE.STREAMER: ProtocolHandler.inr_pause_request,
+                    E_CATE.STREAMER: ProtocolHandler.inr_streamer_pause_request,
                 },
             ),
         )
@@ -472,11 +472,10 @@ class ProtocolMeta:
                 ),
                 decoder=InrPauseRep.from_json,
                 receive_handlers={
-                    E_CATE.STREAMER: ProtocolHandler.inr_pause_response,
-                    E_CATE.DOWNLOADER: ProtocolHandler.inr_pause_response,
+                    E_CATE.STREAMER: ProtocolHandler.inr_streamer_pause_response,
                 },
                 inr_group_receive_handlers={
-                    E_CATE.STREAMER: ProtocolHandler.inr_pause_response_group,
+                    E_CATE.STREAMER: ProtocolHandler.inr_streamer_pause_response_group,
                 },
             ),
         )
@@ -531,8 +530,8 @@ class ProtocolMeta:
                 ),
                 decoder=SeekReq.from_json,
                 receive_handlers={
-                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.seek_request,
-                    E_CATE.STREAMER: ProtocolHandler.seek_request,
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.bridge_seek_request,
+                    E_CATE.STREAMER: ProtocolHandler.streamer_seek_request,
                 },
             ),
         )
@@ -549,7 +548,7 @@ class ProtocolMeta:
                 ),
                 decoder=SeekRep.from_json,
                 receive_handlers={
-                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.seek_response,
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.bridge_seek_response,
                 },
             ),
         )
@@ -566,7 +565,7 @@ class ProtocolMeta:
                 ),
                 decoder=InrSeekReq.from_json,
                 receive_handlers={
-                    E_CATE.STREAMER: ProtocolHandler.inr_seek_request,
+                    E_CATE.STREAMER: ProtocolHandler.inr_streamer_seek_request,
                 },
             ),
         )
@@ -583,11 +582,10 @@ class ProtocolMeta:
                 ),
                 decoder=InrSeekRep.from_json,
                 receive_handlers={
-                    E_CATE.STREAMER: ProtocolHandler.inr_seek_response,
-                    E_CATE.DOWNLOADER: ProtocolHandler.inr_seek_response,
+                    E_CATE.STREAMER: ProtocolHandler.inr_streamer_seek_response,
                 },
                 inr_group_receive_handlers={
-                    E_CATE.STREAMER: ProtocolHandler.inr_seek_response_group,
+                    E_CATE.STREAMER: ProtocolHandler.inr_streamer_seek_response_group,
                 },
             ),
         )
@@ -640,9 +638,9 @@ class ProtocolMeta:
                 ),
                 decoder=CloseReq.from_json,
                 receive_handlers={
-                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.close_request,
-                    E_CATE.STREAMER: ProtocolHandler.close_request,
-                    E_CATE.DOWNLOADER: ProtocolHandler.close_request,
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.bridge_close_request,
+                    E_CATE.STREAMER: ProtocolHandler.streamer_close_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.downloader_close_request,
                 },
             ),
         )
@@ -659,7 +657,7 @@ class ProtocolMeta:
                 ),
                 decoder=CloseRep.from_json,
                 receive_handlers={
-                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.close_response,
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.bridge_close_response,
                 },
             ),
         )
@@ -675,8 +673,8 @@ class ProtocolMeta:
                 ),
                 decoder=InrCloseReq.from_json,
                 receive_handlers={
-                    E_CATE.STREAMER: ProtocolHandler.inr_close_request,
-                    E_CATE.DOWNLOADER: ProtocolHandler.inr_close_request,
+                    E_CATE.STREAMER: ProtocolHandler.inr_streamer_close_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_downloader_close_request,
                 },
             ),
         )
@@ -693,12 +691,12 @@ class ProtocolMeta:
                 ),
                 decoder=InrCloseRep.from_json,
                 receive_handlers={
-                    E_CATE.STREAMER: ProtocolHandler.inr_close_response,
-                    E_CATE.DOWNLOADER: ProtocolHandler.inr_close_response,
+                    E_CATE.STREAMER: ProtocolHandler.inr_streamer_close_response,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_downloader_close_response,
                 },
                 inr_group_receive_handlers={
-                    E_CATE.STREAMER: ProtocolHandler.inr_close_response_group,
-                    E_CATE.DOWNLOADER: ProtocolHandler.inr_close_response_group,
+                    E_CATE.STREAMER: ProtocolHandler.inr_streamer_close_response_group,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_downloader_close_response_group,
                 },
             ),
         )
@@ -751,9 +749,9 @@ class ProtocolMeta:
                 ),
                 decoder=StopReq.from_json,
                 receive_handlers={
-                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.stop_request,
-                    E_CATE.STREAMER: ProtocolHandler.stop_request,
-                    E_CATE.DOWNLOADER: ProtocolHandler.stop_request,
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.bridge_stop_request,
+                    E_CATE.STREAMER: ProtocolHandler.streamer_stop_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.downloader_stop_request,
                 },
             ),
         )
@@ -770,7 +768,7 @@ class ProtocolMeta:
                 ),
                 decoder=StopRep.from_json,
                 receive_handlers={
-                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.stop_response,
+                    E_CATE.MESSAGE_BRIDGE: ProtocolHandler.bridge_stop_response,
                 },
             ),
         )
@@ -786,8 +784,8 @@ class ProtocolMeta:
                 ),
                 decoder=InrStopReq.from_json,
                 receive_handlers={
-                    E_CATE.STREAMER: ProtocolHandler.inr_stop_request,
-                    E_CATE.DOWNLOADER: ProtocolHandler.inr_stop_request,
+                    E_CATE.STREAMER: ProtocolHandler.inr_streamer_stop_request,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_downloader_stop_request,
                 },
             ),
         )
@@ -804,12 +802,12 @@ class ProtocolMeta:
                 ),
                 decoder=InrStopRep.from_json,
                 receive_handlers={
-                    E_CATE.STREAMER: ProtocolHandler.inr_stop_response,
-                    E_CATE.DOWNLOADER: ProtocolHandler.inr_stop_response,
+                    E_CATE.STREAMER: ProtocolHandler.inr_streamer_stop_response,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_downloader_stop_response,
                 },
                 inr_group_receive_handlers={
-                    E_CATE.STREAMER: ProtocolHandler.inr_stop_response_group,
-                    E_CATE.DOWNLOADER: ProtocolHandler.inr_stop_response_group,
+                    E_CATE.STREAMER: ProtocolHandler.inr_streamer_stop_response_group,
+                    E_CATE.DOWNLOADER: ProtocolHandler.inr_downloader_stop_response_group,
                 },
             ),
         )


### PR DESCRIPTION
## Summary
- ProtocolHandler dispatcher 36개 → 60개로 카테고리×메시지 분할 (bridge_/streamer_/downloader_/inr_*_ prefix). 같은 메시지라도 process 타입이 다르면 별도 dispatcher로 분리.
- dispatcher 시그니처는 `IProcess` (base)로 통일하고, 함수 안에서 `assert isinstance(process, ConcreteType)`로 구체 타입 narrowing. C# `PacketHandler`의 `(ClientSession)session` 다운캐스트 의미론과 정확히 대응 (정적 narrowing + 런타임 검증).
- protocol_meta.py 라우팅 테이블 60개 매핑 갱신 + `HandlerFn`/`GroupHandlerFn` 정의에 `IProcess` 사용 (variance 만족).
- dead routing entry 2개 제거 — `INR_PAUSE_REP` / `INR_SEEK_REP`의 `DOWNLOADER` 매핑 (DownloaderManager에 해당 메서드 없음 + 코멘트 "DOWNLOADER 무관"과 일치).
- 부수 수정: `DownloaderManager.handle_playable_list_response` 시그니처를 `PlayableListRep` → `InrPlayableListRep`으로 (실제 매핑은 INR만이라 IMDG 타입은 잘못된 어노테이션이었음).

## Related Issues
- close #102