### PR TITLE
[fix] #106 REST → BRIDGE → STREAMER lifecycle orchestration 일관화

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -4,7 +4,7 @@ CHANNEL_NAME = test
 
 [STORAGE]
 ROOT = /home/shinminbeom/infra_glue/personal/data-pipeline/data
-PREFIX = raw
+PREFIX = split
 
 ; STORAGE_CACHE: downloader가 source에서 받아 로컬에 저장하는 캐시 경로.
 ; 운영 환경에서 STORAGE는 원격(S3/MinIO)으로 교체되지만 STORAGE_CACHE는 항상 로컬.
@@ -40,6 +40,8 @@ AT128_ROOF_REAR_IP = 192.168.20.100
 AT128_ROOF_REAR_PORT = 2370
 AT128_ROOF_LEFT_IP = 192.168.20.100
 AT128_ROOF_LEFT_PORT = 2371
+AM20_FRONT_CENTER_RIGHT_DOWN_IP = 127.0.0.1
+AM20_FRONT_CENTER_RIGHT_DOWN_PORT = 5001
 GNSS_IP = 192.168.20.100
 GNSS_PORT = 5000
 

--- a/src/app/message_bridge/process/message_bridge_process.py
+++ b/src/app/message_bridge/process/message_bridge_process.py
@@ -154,8 +154,21 @@ class MessageBridgeProcess(ImdgBusProcess):
         self.send_message_imdg(envelope)
 
     def handle_pause_request(self, packet: PauseReq) -> None:
-        # PAUSE_REQ는 STREAMER도 broadcast로 받으므로 BRIDGE는 forward 불필요 — no-op.
-        pass
+        """REST에서 받은 PAUSE_REQ를 STREAMER에 forward.
+
+        BRIDGE 자신이 send한 PAUSE_REQ도 receive_handlers로 dispatch되므로 sender로 필터.
+        """
+        from process_category.enum_category import E_CATE
+
+        if not ProtocolOwner.is_owner(packet.sender, E_CATE.REST_SERVER):
+            return
+
+        sender = ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE)
+        receiver = ProtocolOwner.build(E_CATE.STREAMER, E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER)
+        factory = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PAUSE_REQ)
+        fwd_packet = factory(sender, receiver)
+        envelope = ProtocolWrapper.get_protocol_wrapper(fwd_packet).get_protocol_packet_message()
+        self.send_message_imdg(envelope)
 
     def handle_pause_response(self, packet: PauseRep) -> None:
         """STREAMER → MESSAGE_BRIDGE로 들어온 PAUSE_REP를 PD_PAUSE_REP로 변환해 REST_SERVER로 IMDG 송신."""
@@ -178,8 +191,21 @@ class MessageBridgeProcess(ImdgBusProcess):
         self.send_message_imdg(envelope)
 
     def handle_seek_request(self, packet: SeekReq) -> None:
-        # SEEK_REQ는 STREAMER도 broadcast로 받으므로 BRIDGE는 forward 불필요 — no-op.
-        pass
+        """REST에서 받은 SEEK_REQ를 STREAMER에 forward.
+
+        BRIDGE 자신이 send한 SEEK_REQ도 receive_handlers로 dispatch되므로 sender로 필터.
+        """
+        from process_category.enum_category import E_CATE
+
+        if not ProtocolOwner.is_owner(packet.sender, E_CATE.REST_SERVER):
+            return
+
+        sender = ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE)
+        receiver = ProtocolOwner.build(E_CATE.STREAMER, E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER)
+        factory = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.SEEK_REQ)
+        fwd_packet = factory(sender, receiver, packet.start_time)
+        envelope = ProtocolWrapper.get_protocol_wrapper(fwd_packet).get_protocol_packet_message()
+        self.send_message_imdg(envelope)
 
     def handle_seek_response(self, packet: SeekRep) -> None:
         """STREAMER → MESSAGE_BRIDGE로 들어온 SEEK_REP를 PD_SEEK_REP로 변환해 REST_SERVER로 IMDG 송신."""
@@ -202,8 +228,21 @@ class MessageBridgeProcess(ImdgBusProcess):
         self.send_message_imdg(envelope)
 
     def handle_close_request(self, packet: CloseReq) -> None:
-        # CLOSE_REQ는 STREAMER도 broadcast로 받으므로 BRIDGE는 forward 불필요 — no-op.
-        pass
+        """REST에서 받은 CLOSE_REQ를 STREAMER에 forward.
+
+        BRIDGE 자신이 send한 CLOSE_REQ도 receive_handlers로 dispatch되므로 sender로 필터.
+        """
+        from process_category.enum_category import E_CATE
+
+        if not ProtocolOwner.is_owner(packet.sender, E_CATE.REST_SERVER):
+            return
+
+        sender = ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE)
+        receiver = ProtocolOwner.build(E_CATE.STREAMER, E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER)
+        factory = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.CLOSE_REQ)
+        fwd_packet = factory(sender, receiver)
+        envelope = ProtocolWrapper.get_protocol_wrapper(fwd_packet).get_protocol_packet_message()
+        self.send_message_imdg(envelope)
 
     def handle_close_response(self, packet: CloseRep) -> None:
         """STREAMER → MESSAGE_BRIDGE로 들어온 CLOSE_REP를 PD_CLOSE_REP로 변환해 REST_SERVER로 IMDG 송신."""
@@ -226,8 +265,21 @@ class MessageBridgeProcess(ImdgBusProcess):
         self.send_message_imdg(envelope)
 
     def handle_stop_request(self, packet: StopReq) -> None:
-        # STOP_REQ는 STREAMER도 broadcast로 받으므로 BRIDGE는 forward 불필요 — no-op.
-        pass
+        """REST에서 받은 STOP_REQ를 STREAMER에 forward.
+
+        BRIDGE 자신이 send한 STOP_REQ도 receive_handlers로 dispatch되므로 sender로 필터.
+        """
+        from process_category.enum_category import E_CATE
+
+        if not ProtocolOwner.is_owner(packet.sender, E_CATE.REST_SERVER):
+            return
+
+        sender = ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE)
+        receiver = ProtocolOwner.build(E_CATE.STREAMER, E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER)
+        factory = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.STOP_REQ)
+        fwd_packet = factory(sender, receiver)
+        envelope = ProtocolWrapper.get_protocol_wrapper(fwd_packet).get_protocol_packet_message()
+        self.send_message_imdg(envelope)
 
     def handle_stop_response(self, packet: StopRep) -> None:
         """STREAMER → MESSAGE_BRIDGE로 들어온 STOP_REP를 PD_STOP_REP로 변환해 REST_SERVER로 IMDG 송신."""

--- a/src/app/rest/process/socket_io_process.py
+++ b/src/app/rest/process/socket_io_process.py
@@ -68,7 +68,7 @@ class SocketIOProcess(ImdgBusProcess):
         from process_category.enum_category import E_CATE
 
         sender = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
-        receiver = ProtocolOwner.build(E_CATE.STREAMER, E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER)
+        receiver = ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE)
 
         message = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PLAY_REQ)(
             sender,
@@ -91,7 +91,7 @@ class SocketIOProcess(ImdgBusProcess):
         from process_category.enum_category import E_CATE
 
         sender = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
-        receiver = ProtocolOwner.build(E_CATE.STREAMER, E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER)
+        receiver = ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE)
 
         message = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.PAUSE_REQ)(
             sender,
@@ -109,7 +109,7 @@ class SocketIOProcess(ImdgBusProcess):
         from process_category.enum_category import E_CATE
 
         sender = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
-        receiver = ProtocolOwner.build(E_CATE.STREAMER, E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER)
+        receiver = ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE)
 
         message = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.SEEK_REQ)(
             sender,
@@ -128,7 +128,7 @@ class SocketIOProcess(ImdgBusProcess):
         from process_category.enum_category import E_CATE
 
         sender = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
-        receiver = ProtocolOwner.build(E_CATE.STREAMER, E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER)
+        receiver = ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE)
 
         message = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.CLOSE_REQ)(
             sender,
@@ -146,7 +146,7 @@ class SocketIOProcess(ImdgBusProcess):
         from process_category.enum_category import E_CATE
 
         sender = ProtocolOwner.build(E_CATE.REST_SERVER, E_CATE.E_REST_SERVER.E_COMMON.REST_SERVER)
-        receiver = ProtocolOwner.build(E_CATE.STREAMER, E_CATE.E_STREAMER.E_COMMON.STREAMER_MANAGER)
+        receiver = ProtocolOwner.build(E_CATE.MESSAGE_BRIDGE, E_CATE.E_MESSAGE_BRIDGE.E_COMMON.MESSAGE_BRIDGE)
 
         message = ProtocolMeta.get_protocol_factory(E_PROTOCOL_ID.STOP_REQ)(
             sender,


### PR DESCRIPTION
## Summary
- SocketIOProcess의 PAUSE/SEEK/CLOSE/STOP receiver를 STREAMER_MANAGER 직접 송신에서 MESSAGE_BRIDGE로 변경 (PLAY/PLAYABLE_LIST와 동일 패턴). 기존엔 BRIDGE orchestration을 우회해서 StreamerManager의 sender filter에 silent drop되어 PLAY 이후 lifecycle이 모두 timeout이었다.
- MessageBridgeProcess의 4개 lifecycle handler(pause/seek/close/stop)를 no-op에서 STREAMER로 forward로 변경. sender=REST 필터 추가로 BRIDGE 자기 forward와 충돌 방지.
- 검증용 stream_output 매핑(AM20_FRONT_CENTER_RIGHT_DOWN_IP/PORT) conf에 추가.

## 검증
- PLAYABLE_LIST → PLAY 전체 흐름 정상 동작 확인 (REST → BRIDGE → DOWNLOADER → BRIDGE → STREAMER → module → OK).
- 송출 UDP 패킷이 udpsink로 정상 흘러 영상 디코딩까지 가능.
- STOP 응답 timeout은 별개 이슈(STREAMER manager의 STOP state 처리 누락)로 분리 — 본 PR 범위 외.

## Related Issues
- close #106