### PR TITLE
[fix] #108 STREAMER manager PAUSE/SEEK/CLOSE/STOP state broadcast 누락 수정 — active sensors 추적

### DIFF
--- a/src/app/streamer/process/manager/manager.py
+++ b/src/app/streamer/process/manager/manager.py
@@ -21,6 +21,14 @@ class StreamerManager(ImdgBusProcess):
     def __init__(self, app_name, process_name):
         super().__init__(app_name, process_name)
         self.enable_inr_matcher()
+        # PLAY 시점에 저장 — PAUSE/SEEK/CLOSE/STOP broadcast 시 동일 sensor 집합 사용.
+        self._active_sensors: list[str] = []
+
+    def set_active_sensors(self, sensors: list[str]) -> None:
+        self._active_sensors = sensors
+
+    def get_active_sensors(self) -> list[str]:
+        return self._active_sensors
 
     def on_init(self):
         super().on_init()

--- a/src/app/streamer/process/manager/state/close.py
+++ b/src/app/streamer/process/manager/state/close.py
@@ -21,12 +21,9 @@ class CloseState(abState):
     def on_proc_once(self):
         from protocol.protocol_meta import E_PROTOCOL_ID
 
-        # 활성 sensor module list 추적은 후속 작업 — placeholder는 빈 리스트.
-        receivers: list[str] = []
-
         self.owner.broadcast_message_req_inner_queue(
             E_PROTOCOL_ID.INR_CLOSE_REQ,
-            receivers,
+            self.owner.get_active_sensors(),
             rep_protocol_id=E_PROTOCOL_ID.INR_CLOSE_REP,
         )
 

--- a/src/app/streamer/process/manager/state/pause.py
+++ b/src/app/streamer/process/manager/state/pause.py
@@ -21,14 +21,9 @@ class PauseState(abState):
     def on_proc_once(self):
         from protocol.protocol_meta import E_PROTOCOL_ID
 
-        # 모든 sensor module에 INR_PAUSE_REQ broadcast.
-        # receiver_process_names는 Streamer Manager가 보유한 module list — 현 placeholder는 빈 리스트.
-        # 실제 sensor list 추적은 PLAY state 진입 시 owner에 저장 필요 (후속 작업).
-        receivers: list[str] = []
-
         self.owner.broadcast_message_req_inner_queue(
             E_PROTOCOL_ID.INR_PAUSE_REQ,
-            receivers,
+            self.owner.get_active_sensors(),
             rep_protocol_id=E_PROTOCOL_ID.INR_PAUSE_REP,
         )
 

--- a/src/app/streamer/process/manager/state/play.py
+++ b/src/app/streamer/process/manager/state/play.py
@@ -23,6 +23,9 @@ class PlayState(abState):
 
         assert isinstance(self.state_param_dto, PlayReq)
 
+        # 후속 lifecycle(PAUSE/SEEK/CLOSE/STOP) broadcast 시 동일 sensor 집합 사용.
+        self.owner.set_active_sensors(self.state_param_dto.sensor_id_list)
+
         self.owner.broadcast_message_req_inner_queue(
             E_PROTOCOL_ID.INR_PLAY_REQ,
             self.state_param_dto.sensor_id_list,

--- a/src/app/streamer/process/manager/state/seek.py
+++ b/src/app/streamer/process/manager/state/seek.py
@@ -23,12 +23,9 @@ class SeekState(abState):
 
         assert isinstance(self.state_param_dto, SeekReq)
 
-        # 활성 sensor module list 추적은 후속 작업 — placeholder는 빈 리스트.
-        receivers: list[str] = []
-
         self.owner.broadcast_message_req_inner_queue(
             E_PROTOCOL_ID.INR_SEEK_REQ,
-            receivers,
+            self.owner.get_active_sensors(),
             self.state_param_dto.start_time,
             rep_protocol_id=E_PROTOCOL_ID.INR_SEEK_REP,
         )

--- a/src/app/streamer/process/manager/state/stop.py
+++ b/src/app/streamer/process/manager/state/stop.py
@@ -21,12 +21,9 @@ class StopState(abState):
     def on_proc_once(self):
         from protocol.protocol_meta import E_PROTOCOL_ID
 
-        # 활성 sensor module list 추적은 후속 작업 — placeholder는 빈 리스트.
-        receivers: list[str] = []
-
         self.owner.broadcast_message_req_inner_queue(
             E_PROTOCOL_ID.INR_STOP_REQ,
-            receivers,
+            self.owner.get_active_sensors(),
             rep_protocol_id=E_PROTOCOL_ID.INR_STOP_REP,
         )
 


### PR DESCRIPTION
## Summary
- StreamerManager의 PAUSE/SEEK/CLOSE/STOP state의 on_proc_once가 receivers를 빈 리스트로 broadcast해서 어떤 module도 메시지를 못 받던 placeholder 상태 해결. PLAY는 state_param_dto.sensor_id_list로 정상 broadcast하지만 다른 state는 활성 sensor 추적이 미구현이었음.
- StreamerManager에 active_sensors 필드와 setter/getter 추가. PlayState에서 PLAY 진입 시 sensor_id_list 저장, 후속 lifecycle state는 동일 sensor 집합으로 INR_*_REQ broadcast.
- 결과: PLAY 후 PAUSE/SEEK/CLOSE/STOP 요청이 module에 정상 전달되어 응답 흐름 완성. manager state stuck 해소.

## 검증
- 사전 검증: replayer 프로젝트(infra-glue-conditions-replayer)의 동일 패턴(GetStreamingProcessSet/SetStreamingProcessSet)과 일치 확인.
- 본 PR의 자연스러운 후속 검증은 4앱 재시작 후 PLAY → STOP → STOP_REP OK 응답 확인.

## Related Issues
- close #108