### PR TITLE
[chore] #117 inner queue 로그 prefix [IQ] → [INNER_QUEUE]

### DIFF
--- a/src/common/event_bus/inner_queue_bus.py
+++ b/src/common/event_bus/inner_queue_bus.py
@@ -21,8 +21,8 @@ class InnerQueueBus(abEventBus[QueueControlProcess]):
         wrapper = ProtocolWrapper.get_protocol_wrapper(packet)
         envelope = wrapper.get_protocol_packet_message()
         log = AppLogger.instance()
-        log.info(f"[IQ SEND] {wrapper.summary(packet)}")
-        log.debug(f"[IQ SEND payload] {envelope}")
+        log.info(f"[INNER_QUEUE SEND] {wrapper.summary(packet)}")
+        log.debug(f"[INNER_QUEUE SEND payload] {envelope}")
         self.send_message_inner_queue(receiver_process_name, envelope)
 
     def send_message_req_inner_queue(

--- a/src/common/event_bus/listener/inner_queue_listener.py
+++ b/src/common/event_bus/listener/inner_queue_listener.py
@@ -26,8 +26,8 @@ class InnerQueueListener(abListener[QueueControlProcess]):
         wrapper, packet = ProtocolWrapper.decode_protocol_wrapper_with_message_protocol(envelope)
 
         log = AppLogger.instance()
-        log.info(f"[IQ RECV] {wrapper.summary(packet)}")
-        log.debug(f"[IQ RECV payload] {envelope}")
+        log.info(f"[INNER_QUEUE RECV] {wrapper.summary(packet)}")
+        log.debug(f"[INNER_QUEUE RECV payload] {envelope}")
 
         # 1. 개별 핸들러 (응답마다 1회)
         ProtocolMeta.get_receive_handler(wrapper.protocol_id, receiver)(


### PR DESCRIPTION
## Summary
- inner queue 이벤트 버스의 로그 prefix를 `[IQ]` → `[INNER_QUEUE]`로 풀어 표기 (가독성 개선)
- 변경 파일: `src/common/event_bus/inner_queue_bus.py` (SEND 2줄), `src/common/event_bus/listener/inner_queue_listener.py` (RECV 2줄)

## Related Issues
- close #117